### PR TITLE
fix: most tests are failing (crashing) due to lack of refcount increase

### DIFF
--- a/otel_observer.c
+++ b/otel_observer.c
@@ -309,9 +309,11 @@ static void find_observers(HashTable *ht, zend_string *n, zend_llist *pre_hooks,
     otel_observer *observer = zend_hash_find_ptr_lc(ht, n);
     if (observer) {
         for (zend_llist_element *element = observer->pre_hooks.head; element; element = element->next) {
+            zval_add_ref((zval*)&element->data);
             zend_llist_add_element(pre_hooks, &element->data);
         }
         for (zend_llist_element *element = observer->post_hooks.head; element; element = element->next) {
+            zval_add_ref((zval*)&element->data);
             zend_llist_add_element(post_hooks, &element->data);
         }
     }


### PR DESCRIPTION
Testing it on PHP-8.2. In debug mode it results in following assertion `Assertion failed: (zval_gc_type((ref)->gc.u.type_info) == 7 || zval_gc_type((ref)->gc.u.type_info) == 8), function gc_possible_root, file zend_gc.c, line 647`


`PASS Check if otel_instrumentation is loaded [tests/001.phpt] `
`PASS Check if hook returns true [tests/002.phpt] `
`FAIL Check if hooks are invoked [tests/003.phpt] `
`FAIL Check if multiple hooks are invoked [tests/004.phpt] `
`FAIL Check if hooks receives function information [tests/005.phpt] `
`FAIL Check if hooks receives arguments and return value [tests/006.phpt] `
`FAIL Check if hook receives exception [tests/007.phpt] `
`FAIL Check if hook can modify arguments [tests/008.phpt] `
`FAIL Check if hook can modify not provided arguments [tests/009.phpt] `
`FAIL Check if hook can modify return value [tests/010.phpt] `
`FAIL Check if hooks are invoked for closures [tests/function_closure.phpt] `
`FAIL Check if hooks are invoked for first class callables [tests/function_first_class_callable.phpt] `
`