### PR TITLE
Fix minor issues with returns

### DIFF
--- a/otel_instrumentation.c
+++ b/otel_instrumentation.c
@@ -41,6 +41,8 @@ PHP_RINIT_FUNCTION(otel_instrumentation) {
 
 PHP_RSHUTDOWN_FUNCTION(otel_instrumentation) {
     observer_globals_cleanup();
+
+    return SUCCESS;
 }
 
 PHP_MINIT_FUNCTION(otel_instrumentation) {

--- a/otel_observer.c
+++ b/otel_observer.c
@@ -426,7 +426,7 @@ static void add_method_observer(HashTable *ht, zend_string *cn, zend_string *fn,
 
 bool add_observer(zend_string *cn, zend_string *fn, zval *pre_hook, zval *post_hook) {
     if (op_array_extension == -1) {
-        return 0;
+        return false;
     }
 
     if (cn) {
@@ -435,7 +435,7 @@ bool add_observer(zend_string *cn, zend_string *fn, zval *pre_hook, zval *post_h
         add_function_observer(OTEL_G(observer_function_lookup), fn, pre_hook, post_hook);
     }
 
-    return 1;
+    return true;
 }
 
 void observer_globals_init(void) {


### PR DESCRIPTION
`PHP_RSHUTDOWN_FUNCTION` should return `zend_result`.

`add_observer` returns bool, not int, so use true and false instead of 1 and true.