### PR TITLE
fix: propagate return value modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ The following example adds an observer to the `DemoClass::run` method, and provi
 
 The `pre` method starts and activates a span. The `post` method ends the span after the observed method has finished.
 
+#### Warning
+Be aware of that, trivial functions are candidates for optimizations.
+Optimizer can optimize them out and replace user function call with more optimal set of instructions (inlining).
+In this case hooks will not be invoked as there will be no function.
+
+
 ```php
 <?php
 

--- a/otel_observer.c
+++ b/otel_observer.c
@@ -259,7 +259,7 @@ static void observer_end(zend_execute_data *execute_data, zval *retval, zend_lli
                 if (execute_data->return_value) {
                     zval_ptr_dtor(execute_data->return_value);
                     ZVAL_COPY(execute_data->return_value, &ret);
-                    // TODO Update params[2]
+                    params[2] = ret;
                 }
             }
         }

--- a/tests/multiple_hooks_modify_returnvalue.phpt
+++ b/tests/multiple_hooks_modify_returnvalue.phpt
@@ -6,14 +6,19 @@ otel_instrumentation
 <?php
 \OpenTelemetry\Instrumentation\hook(null, 'helloWorld', post: fn(mixed $object, array $params, string $return): string => ++$return);
 \OpenTelemetry\Instrumentation\hook(null, 'helloWorld', post: fn(mixed $object, array $params, string $return): string => ++$return);
+//\OpenTelemetry\Instrumentation\hook(null, 'helloWorld', null, fn(): string => 'b');
 
 function helloWorld() {
+    // below instruction (or any equivalent) is needed
+    // to prevent optimizer to optimize out
+    // helloWorld call and generate DO_UCALL
+    // otherwise hooks will not be invoked
+    // as there will be no function
+    echo ' ';
     return 'a';
 }
 
 var_dump(helloWorld());
 ?>
---XFAIL--
-Return value modifications are not propagated between callbacks.
 --EXPECT--
 string(1) "c"


### PR DESCRIPTION
Without additional echo call in helloWorld, code for main looks as follows 
`$_main:
     ; (lines=4, args=0, vars=0, tmps=1)
     ; (after optimizer)
     ; /Users/pdelewski/Projects/php-auto/test3.php:1-8
0000 INIT_FCALL 1 112 string("var_dump")
0001 SEND_VAL int(1) 1
0002 DO_ICALL
0003 RETURN int(1)`

which means that call to helloWorld has been optimized out and in result hooks are not invoked