### PR TITLE
fix: throwing new exception from post hook lead to memory leak

### DIFF
--- a/otel_observer.c
+++ b/otel_observer.c
@@ -263,11 +263,16 @@ static void observer_end(zend_execute_data *execute_data, zval *retval, zend_lli
                 }
             }
         }
-        
+
         if (UNEXPECTED(EG(exception))) {
+            if (exception) {
+                OBJ_RELEASE(exception);
+            }
+            OBJ_RELEASE(Z_OBJ(params[3]));
+
             ZVAL_OBJ_COPY(&params[3], EG(exception));
         }
-        
+
         zend_exception_restore();
         EG(prev_exception) = exception;
         zend_exception_restore();


### PR DESCRIPTION
All tests are passing now on debug build without memory problems

```
=====================================================================
PHP         : /Users/pdelewski/php-bin/DEBUG/bin/php 
PHP_SAPI    : cli
PHP_VERSION : 8.2.0-dev
ZEND_VERSION: 4.2.0-dev

=====================================================================
TIME START 2022-11-24 11:27:20
=====================================================================
PASS Check if otel_instrumentation is loaded [tests/001.phpt] 
PASS Check if hook returns true [tests/002.phpt] 
PASS Check if hooks are invoked [tests/003.phpt] 
PASS Check if multiple hooks are invoked [tests/004.phpt] 
PASS Check if hooks receives function information [tests/005.phpt] 
PASS Check if hooks receives arguments and return value [tests/006.phpt] 
PASS Check if hook receives exception [tests/007.phpt] 
PASS Check if hook can modify arguments [tests/008.phpt] 
PASS Check if hook can modify not provided arguments [tests/009.phpt] 
PASS Check if hook can modify return value [tests/010.phpt] 
PASS Check if hooks are invoked for closures [tests/function_closure.phpt] 
PASS Check if hooks are invoked for first class callables [tests/function_first_class_callable.phpt] 
PASS Check if hooks receive modified exception [tests/multiple_hooks_modify_exception.phpt] 
PASS Check if hooks receive modified arguments [tests/multiple_hooks_modify_params.phpt] 
PASS Check if hooks receive modified returnvalue [tests/multiple_hooks_modify_returnvalue.phpt] 
XFAIL Check if hooks are invoked only once for reimplemented interfaces [tests/reimplemented_interface.phpt]   XFAIL REASON: Repeated interfaces are not deduplicated, A::m() hook is added for C->A and C->B->A.

```