### PR TITLE
windows is not supported yet due to configure script code generation …

### DIFF
--- a/bin/install.php
+++ b/bin/install.php
@@ -122,6 +122,8 @@ function check_preconditions() {
     exit(-1);
   }
   if (PHP_OS_FAMILY === "Windows") {
+    colorLog("windows is not supported yet", 'e');
+    exit(-1);
     if (!command_exists("cl") && !command_exists("link")) {
       colorLog("c compiler is not installed or not available", 'e');
       exit(-1);


### PR DESCRIPTION
As discussed yesterday installation on windows is failing due to https://github.com/open-telemetry/opentelemetry-php-instrumentation/issues/32, so in this case `install.sh` will shutdown gracefully