### PR TITLE
store scope in the context

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ OpenTelemetry\Instrumentation\hook(
     DemoClass::class,
     'run',
     static function (DemoClass $demo, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($tracer) {
-        $tracer->spanBuilder($class)
-            ->startSpan()
-            ->activate();
+        $span = $tracer->spanBuilder($class)
+            ->startSpan();
+        Context::storage()->attach($span->storeInContext(Context::getCurrent()));
     },
     static function (DemoClass $demo, array $params, $returnValue, ?Throwable $exception) use ($tracer) {
         $scope = Context::storage()->scope();


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-php-instrumentation/issues/41

Maybe better would be prepare fully working example and do some improvements in https://github.com/open-telemetry/opentelemetry-php/blob/main/src/Context/DebugScope.php?