### PR TITLE
handle UnwindExit

### DIFF
--- a/otel_observer.c
+++ b/otel_observer.c
@@ -99,8 +99,11 @@ static inline void func_get_retval(zval *zv, zval *retval) {
 }
 
 static inline void func_get_exception(zval *zv) {
-    if (UNEXPECTED(EG(exception))) {
-        ZVAL_OBJ_COPY(zv, EG(exception));
+    zend_object *exception = EG(exception);
+    if (exception && zend_is_unwind_exit(exception)) {
+        ZVAL_NULL(zv);
+    } else if (UNEXPECTED(exception)) {
+        ZVAL_OBJ_COPY(zv, exception);
     } else {
         ZVAL_NULL(zv);
     }

--- a/tests/unwind_exit.phpt
+++ b/tests/unwind_exit.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Test UnwindExit from die/exit is not exposed to userland code
+--XFAIL--
+UnwindExit is internal and should not be exposed to userland code. We need to decide whether to not run
+post callback, or drop the UnwindExit and call the callback with null.
+--EXTENSIONS--
+opentelemetry
+--FILE--
+
+<?php
+
+use function OpenTelemetry\Instrumentation\hook;
+
+class TestClass {
+    public static function run(): void
+    {
+       die('exit!');
+    }
+}
+
+hook(
+    'TestClass',
+    'run',
+    null,
+    static function ($object, array $params, mixed $ret, ?\Throwable $exception ) {
+      //@todo whether this code should run or not (after die/exit) needs to be decided
+      echo 'this code should not run';
+    }
+);
+
+TestClass::run();
+?>
+
+--EXPECT--
+exit!

--- a/tests/unwind_exit.phpt
+++ b/tests/unwind_exit.phpt
@@ -1,8 +1,5 @@
 --TEST--
 Test UnwindExit from die/exit is not exposed to userland code
---XFAIL--
-UnwindExit is internal and should not be exposed to userland code. We need to decide whether to not run
-post callback, or drop the UnwindExit and call the callback with null.
 --EXTENSIONS--
 opentelemetry
 --FILE--
@@ -23,8 +20,7 @@ hook(
     'run',
     null,
     static function ($object, array $params, mixed $ret, ?\Throwable $exception ) {
-      //@todo whether this code should run or not (after die/exit) needs to be decided
-      echo 'this code should not run';
+      echo PHP_EOL . 'post';
     }
 );
 
@@ -33,3 +29,4 @@ TestClass::run();
 
 --EXPECT--
 exit!
+post


### PR DESCRIPTION
Do not pass UnwindExit to post observer callback

Related: https://github.com/open-telemetry/opentelemetry-php/issues/951