### PR TITLE
fixing segfault when returning params from pre callback

### DIFF
--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -171,6 +171,11 @@ static void observer_begin(zend_execute_data *execute_data, zend_llist *hooks) {
             if (Z_TYPE(ret) == IS_ARRAY) {
                 zend_ulong idx;
                 zval *val;
+                if (zend_is_identical(&ret, &params[1])) {
+                    // the input $params was returned
+                    zval_dtor(&params[1]);
+                    continue;
+                }
                 ZEND_HASH_FOREACH_NUM_KEY_VAL(Z_ARR(ret), idx, val) {
                     zval *target = NULL;
                     uint32_t arg_count = ZEND_CALL_NUM_ARGS(execute_data);

--- a/ext/tests/return_params.phpt
+++ b/ext/tests/return_params.phpt
@@ -12,7 +12,5 @@ function helloWorld($a) {
 
 helloWorld('a');
 ?>
---XFAIL--
-Core dump (assertion) on refcount
 --EXPECT--
 string(1) "a"

--- a/ext/tests/return_params_internal.phpt
+++ b/ext/tests/return_params_internal.phpt
@@ -10,7 +10,5 @@ opentelemetry
 
 array_map(var_dump(...), ['HELLO']);
 ?>
---XFAIL--
-Core dump (assertion) on refcount
 --EXPECT--
 string(5) "HELLO"


### PR DESCRIPTION
when the original $params array is returned (with or without modification), we do not need any extra processing to replace the original parameters - that is already taken care of.