### PR TITLE
adding notes and minor code improvements for issue 68

### DIFF
--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -168,14 +168,9 @@ static void observer_begin(zend_execute_data *execute_data, zend_llist *hooks) {
         EG(prev_exception) = NULL;
 
         if (zend_call_function(&fci, &fcc) == SUCCESS) {
-            if (Z_TYPE(ret) == IS_ARRAY) {
+            if (Z_TYPE(ret) == IS_ARRAY && !zend_is_identical(&ret, &params[1])) {
                 zend_ulong idx;
                 zval *val;
-                if (zend_is_identical(&ret, &params[1])) {
-                    // the input $params was returned
-                    zval_dtor(&params[1]);
-                    continue;
-                }
                 ZEND_HASH_FOREACH_NUM_KEY_VAL(Z_ARR(ret), idx, val) {
                     zval *target = NULL;
                     uint32_t arg_count = ZEND_CALL_NUM_ARGS(execute_data);
@@ -195,9 +190,7 @@ static void observer_begin(zend_execute_data *execute_data, zend_llist *hooks) {
                         zval_dtor(target);
                         ZVAL_COPY(target, val);
                         if (Z_TYPE(params[1]) == IS_ARRAY) {
-                            if (Z_REFCOUNTED_P(val)) {
-                                Z_ADDREF_P(val);
-                            }
+                            Z_TRY_ADDREF_P(val);
                             zend_hash_index_update(Z_ARR(params[1]), idx, val);
                         }
                     }

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -168,7 +168,8 @@ static void observer_begin(zend_execute_data *execute_data, zend_llist *hooks) {
         EG(prev_exception) = NULL;
 
         if (zend_call_function(&fci, &fcc) == SUCCESS) {
-            if (Z_TYPE(ret) == IS_ARRAY && !zend_is_identical(&ret, &params[1])) {
+            if (Z_TYPE(ret) == IS_ARRAY &&
+                !zend_is_identical(&ret, &params[1])) {
                 zend_ulong idx;
                 zval *val;
                 ZEND_HASH_FOREACH_NUM_KEY_VAL(Z_ARR(ret), idx, val) {

--- a/ext/tests/expand_params_internal.phpt
+++ b/ext/tests/expand_params_internal.phpt
@@ -1,7 +1,10 @@
 --TEST--
 Check if pre hook can expand params of internal function
 --DESCRIPTION--
-The segfault is actually during shutdown (garbage collection?). Removing the `post` callback avoids the segfault.
+Removing the `post` callback avoids the segfault. The segfault is actually during shutdown,
+from `zend_observer_fcall_end_all` (https://github.com/php/php-src/blob/php-8.2.8/Zend/zend_observer.c#L291).
+When it traverses back through zend_execute_data, the top-level frame appears corrupted, and any attempt to reference
+it is what causes the segfault.
 --EXTENSIONS--
 opentelemetry
 --XFAIL--


### PR DESCRIPTION
when debugging issue 68 (expand params of internal function causes segfault), I gained more understanding of what's going on, but no solution yet. Documenting my findings in the .phpt test.
Also, small refactor/tidy of some of the code based on my testing. Replace refcount check with macro, per https://www.phpinternalsbook.com/php7/zvals/memory_management.html

Related: #68 