### PR TITLE
check for invalid hook function signatures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,6 @@ jobs:
       -   name: Test
           env:
             TEST_PHP_ARGS: "-q" #do not try to submit failures
-          run: make test
+          run: |
+            make test
+            find tests -name "*.diff" -exec echo -e "\n\n"{} \; -exec cat {} \;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
       -   name: Test
           env:
             TEST_PHP_ARGS: "-q" #do not try to submit failures
-          run: |
-            make test
-            find tests -name "*.diff" -exec echo -e "\n\n"{} \; -exec cat {} \;
+          run: make test
+
+      -   name: Print failures
+          run: find tests -name "*.diff" -exec echo -e "\n\n"{} \; -exec cat {} \;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,4 @@ jobs:
       -   name: Test
           env:
             TEST_PHP_ARGS: "-q" #do not try to submit failures
-          run: make test
-
-      -   name: Print failures
-          run: find tests -name "*.diff" -exec echo -e "\n\n"{} \; -exec cat {} \;
+          run: make test TESTS=--show-diff

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ php --ri  opentelemetry
 
 ## Known issues
 
+### Conflicting extensions
+
 The OpenTelemetry extension does not play nicely with the following other extensions:
 - blackfire
 
@@ -58,12 +60,21 @@ Notice: PHP Startup: Conflicting extension found (blackfire), disabling OpenTele
 
 opentelemetry
 
-opentelemetry support => disabled
+opentelemetry hooks => disabled (conflict)
 extension version => 1.0.0beta6
 
 Directive => Local Value => Master Value
 opentelemetry.conflicts => blackfire => blackfire
+opentelemetry.validate_hook_functions => On => On
 ```
+
+### Invalid pre/post hooks
+
+Invalid argument types in pre and post callbacks can cause fatal errors. Runtime checking is performed on the
+hook functions to ensure they are compatible. If not, the hook will not be executed and an error will be logged
+to error_log.
+
+This feature can be disabled by setting the `opentelemetry.validate_hook_functions` ini value to `Off`;
 
 ## Usage
 

--- a/ext/opentelemetry.c
+++ b/ext/opentelemetry.c
@@ -30,12 +30,12 @@ static int check_conflict(HashTable *registry, const char *extension_name) {
     return 0;
 }
 
-static int check_conflicts() {
+static void check_conflicts() {
     int conflict_found = 0;
     char *input = OTEL_G(conflicts);
 
     if (!input || !*input) {
-        return 0;
+        return;
     }
 
     HashTable *registry = &module_registry;

--- a/ext/opentelemetry.c
+++ b/ext/opentelemetry.c
@@ -12,9 +12,7 @@
 #include "string.h"
 #include "zend_closures.h"
 
-static int disabled = 0;
-
-static int check_conflict(HashTable *registry, char *extension_name) {
+static int check_conflict(HashTable *registry, const char *extension_name) {
     if (!extension_name || !*extension_name) {
         return 0;
     }
@@ -34,7 +32,7 @@ static int check_conflict(HashTable *registry, char *extension_name) {
 
 static int check_conflicts() {
     int conflict_found = 0;
-    const char *input = INI_STR("opentelemetry.conflicts");
+    char *input = OTEL_G(conflicts);
 
     if (!input || !*input) {
         return 0;
@@ -52,7 +50,7 @@ static int check_conflicts() {
                 size_t len = e - s;
                 char *result = (char *)malloc((len + 1) * sizeof(char));
                 strncpy(result, s, len);
-                result[len] = NULL; // null terminate
+                result[len] = '\0'; // null terminate
                 if (check_conflict(registry, result)) {
                     conflict_found = 1;
                 }
@@ -71,10 +69,21 @@ static int check_conflicts() {
         conflict_found = 1;
     }
 
-    return conflict_found;
+    OTEL_G(disabled) = conflict_found;
 }
 
 ZEND_DECLARE_MODULE_GLOBALS(opentelemetry)
+
+PHP_INI_BEGIN()
+// conflicting extensions. a comma-separated list, eg "ext1,ext2"
+STD_PHP_INI_ENTRY("opentelemetry.conflicts", "blackfire", PHP_INI_ALL,
+                  OnUpdateString, conflicts, zend_opentelemetry_globals,
+                  opentelemetry_globals)
+STD_PHP_INI_ENTRY_EX("opentelemetry.validate_hook_functions", "On", PHP_INI_ALL,
+                     OnUpdateBool, validate_hook_functions,
+                     zend_opentelemetry_globals, opentelemetry_globals,
+                     zend_ini_boolean_displayer_cb)
+PHP_INI_END()
 
 PHP_FUNCTION(hook) {
     zend_string *class_name;
@@ -103,11 +112,6 @@ PHP_RINIT_FUNCTION(opentelemetry) {
     return SUCCESS;
 }
 
-PHP_INI_BEGIN()
-// default conflicting extensions. a comma-separated list, eg "ext1,ext2"
-PHP_INI_ENTRY("opentelemetry.conflicts", "blackfire", PHP_INI_ALL, NULL)
-PHP_INI_END()
-
 PHP_RSHUTDOWN_FUNCTION(opentelemetry) {
     UNREGISTER_INI_ENTRIES();
     observer_globals_cleanup();
@@ -118,9 +122,9 @@ PHP_RSHUTDOWN_FUNCTION(opentelemetry) {
 PHP_MINIT_FUNCTION(opentelemetry) {
     REGISTER_INI_ENTRIES();
 
-    disabled = check_conflicts();
+    check_conflicts();
 
-    if (!disabled) {
+    if (!OTEL_G(disabled)) {
         opentelemetry_observer_init(INIT_FUNC_ARGS_PASSTHRU);
     }
 
@@ -129,8 +133,9 @@ PHP_MINIT_FUNCTION(opentelemetry) {
 
 PHP_MINFO_FUNCTION(opentelemetry) {
     php_info_print_table_start();
-    php_info_print_table_header(2, "opentelemetry support",
-                                disabled ? "disabled" : "enabled");
+    php_info_print_table_row(2, "opentelemetry hooks",
+                             OTEL_G(disabled) ? "disabled (conflict)"
+                                              : "enabled");
     php_info_print_table_row(2, "extension version", PHP_OPENTELEMETRY_VERSION);
     php_info_print_table_end();
     DISPLAY_INI_ENTRIES();

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -146,9 +146,13 @@ bool is_object_compatible_with_type_hint(zval *object_zval,
  * Check if pre/post function callback's signature is compatible with
  * the expected function signature.
  * This is a runtime check, since some parameters are only known at runtime.
+ * Can be disabled via the opentelemetry.check_hook_functions ini value.
  */
 static inline bool is_valid_signature(zend_fcall_info fci,
                                       zend_fcall_info_cache fcc) {
+    if (OTEL_G(validate_hook_functions) == 0) {
+        return 1;
+    }
     zend_function *func = fcc.function_handler;
     zend_arg_info *arg_info;
     zend_type *arg_type;

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -228,7 +228,8 @@ static void observer_begin(zend_execute_data *execute_data, zend_llist *hooks) {
         fci.retval = &ret;
 
         if (!is_valid_signature(fci, fcc)) {
-            char *msg = "OpenTelemetry: pre hook invalid signature, class=%s function=%s";
+            char *msg = "OpenTelemetry: pre hook invalid signature, class=%s "
+                        "function=%s";
             log_invalid_message(msg, &params[2], &params[3]);
             continue;
         }
@@ -343,7 +344,8 @@ static void observer_end(zend_execute_data *execute_data, zval *retval,
         fci.retval = &ret;
 
         if (!is_valid_signature(fci, fcc)) {
-            char *msg = "OpenTelemetry: post hook invalid signature, class=%s function=%s";
+            char *msg = "OpenTelemetry: post hook invalid signature, class=%s "
+                        "function=%s";
             log_invalid_message(msg, &params[4], &params[5]);
             continue;
         }

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -136,7 +136,8 @@ static inline void func_get_lineno(zval *zv, zend_execute_data *ex) {
 /**
  * Check if the object implements or extends the specified class
  */
-bool is_object_compatible_with_type_hint(zval *object_zval, zend_class_entry *type_hint) {
+bool is_object_compatible_with_type_hint(zval *object_zval,
+                                         zend_class_entry *type_hint) {
     zend_class_entry *object_ce = Z_OBJCE_P(object_zval);
     return instanceof_function(object_ce, type_hint);
 }
@@ -146,34 +147,35 @@ bool is_object_compatible_with_type_hint(zval *object_zval, zend_class_entry *ty
  * the expected function signature.
  * This is a runtime check, since some parameters are only known at runtime.
  */
-static inline bool is_valid_signature(zend_fcall_info fci, zend_fcall_info_cache fcc) {
+static inline bool is_valid_signature(zend_fcall_info fci,
+                                      zend_fcall_info_cache fcc) {
     zend_function *func = fcc.function_handler;
-    zend_arg_info* arg_info;
-    zend_type* arg_type;
-    zend_string* arg_name;
+    zend_arg_info *arg_info;
+    zend_type *arg_type;
+    zend_string *arg_name;
     uint32_t type;
     uint32_t type_mask;
 
     for (uint32_t i = 0; i < func->common.num_args; i++) {
-        //get type mask of callback argument
+        // get type mask of callback argument
         arg_info = &func->common.arg_info[i];
         arg_type = &arg_info->type;
         type_mask = arg_type->type_mask;
 
-        //get actual value + type
+        // get actual value + type
         zval param = fci.params[i];
         type = Z_TYPE(fci.params[i]);
 
         if (arg_type->type_mask == 0) {
             // no type mask -> ok
         } else if (Z_TYPE(param) == IS_OBJECT) {
-            //object special-case handling (check for interfaces, subclasses)
-            zend_class_entry* ce = Z_OBJCE(param);
+            // object special-case handling (check for interfaces, subclasses)
+            zend_class_entry *ce = Z_OBJCE(param);
             if (!is_object_compatible_with_type_hint(&param, ce)) {
                 return false;
             }
         } else if ((type_mask & (1 << type)) == 0) {
-            //type is not compatible with mask
+            // type is not compatible with mask
             return false;
         }
     }

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -133,6 +133,54 @@ static inline void func_get_lineno(zval *zv, zend_execute_data *ex) {
     }
 }
 
+/**
+ * Check if the object implements or extends the specified class
+ */
+bool is_object_compatible_with_type_hint(zval *object_zval, zend_class_entry *type_hint) {
+    zend_class_entry *object_ce = Z_OBJCE_P(object_zval);
+    return instanceof_function(object_ce, type_hint);
+}
+
+/**
+ * Check if pre/post function callback's signature is compatible with
+ * the expected function signature.
+ * This is a runtime check, since some parameters are only known at runtime.
+ */
+static inline bool is_valid_signature(zend_fcall_info fci, zend_fcall_info_cache fcc) {
+    zend_function *func = fcc.function_handler;
+    zend_arg_info* arg_info;
+    zend_type* arg_type;
+    zend_string* arg_name;
+    uint32_t type;
+    uint32_t type_mask;
+
+    for (uint32_t i = 0; i < func->common.num_args; i++) {
+        //get type mask of callback argument
+        arg_info = &func->common.arg_info[i];
+        arg_type = &arg_info->type;
+        type_mask = arg_type->type_mask;
+
+        //get actual value + type
+        zval param = fci.params[i];
+        type = Z_TYPE(fci.params[i]);
+
+        if (arg_type->type_mask == 0) {
+            // no type mask -> ok
+        } else if (Z_TYPE(param) == IS_OBJECT) {
+            //object special-case handling (check for interfaces, subclasses)
+            zend_class_entry* ce = Z_OBJCE(param);
+            if (!is_object_compatible_with_type_hint(&param, ce)) {
+                return false;
+            }
+        } else if ((type_mask & (1 << type)) == 0) {
+            //type is not compatible with mask
+            return false;
+        }
+    }
+
+    return true;
+}
+
 static void observer_begin(zend_execute_data *execute_data, zend_llist *hooks) {
     if (!zend_llist_count(hooks)) {
         return;
@@ -162,6 +210,10 @@ static void observer_begin(zend_execute_data *execute_data, zend_llist *hooks) {
         fci.params = params;
         fci.named_params = NULL;
         fci.retval = &ret;
+
+        if (!is_valid_signature(fci, fcc)) {
+            continue;
+        }
 
         zend_exception_save();
         zend_object *exception = EG(prev_exception);
@@ -267,6 +319,10 @@ static void observer_end(zend_execute_data *execute_data, zval *retval,
         fci.params = params;
         fci.named_params = NULL;
         fci.retval = &ret;
+
+        if (!is_valid_signature(fci, fcc)) {
+            continue;
+        }
 
         zend_exception_save();
         zend_object *exception = EG(prev_exception);

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -166,7 +166,7 @@ static inline bool is_valid_signature(zend_fcall_info fci,
         zval param = fci.params[i];
         type = Z_TYPE(fci.params[i]);
 
-        if (arg_type->type_mask == 0) {
+        if ((type_mask == IS_UNDEF)) {
             // no type mask -> ok
         } else if (Z_TYPE(param) == IS_OBJECT) {
             // object special-case handling (check for interfaces, subclasses)

--- a/ext/php_opentelemetry.h
+++ b/ext/php_opentelemetry.h
@@ -9,6 +9,9 @@ ZEND_BEGIN_MODULE_GLOBALS(opentelemetry)
     HashTable *observer_class_lookup;
     HashTable *observer_function_lookup;
     HashTable *observer_aggregates;
+    int validate_hook_functions;
+    char *conflicts;
+    int disabled; // module disabled? (eg due to conflicting extension loaded)
 ZEND_END_MODULE_GLOBALS(opentelemetry)
 
 ZEND_EXTERN_MODULE_GLOBALS(opentelemetry)

--- a/ext/tests/007.phpt
+++ b/ext/tests/007.phpt
@@ -8,7 +8,7 @@ opentelemetry
     null,
     'helloWorld',
     null,
-    fn(object|string|null $scope, array $params, mixed $returnValue, ?Throwable $throwable) => var_dump($throwable?->getMessage()));
+    fn(null $obj, array $params, mixed $returnValue, ?Throwable $throwable) => var_dump($throwable?->getMessage()));
 
 function helloWorld() {
     throw new Exception('error');

--- a/ext/tests/007.phpt
+++ b/ext/tests/007.phpt
@@ -8,7 +8,7 @@ opentelemetry
     null,
     'helloWorld',
     null,
-    fn(null $obj, array $params, mixed $returnValue, ?Throwable $throwable) => var_dump($throwable?->getMessage()));
+    fn(object|null $obj, array $params, mixed $returnValue, ?Throwable $throwable) => var_dump($throwable?->getMessage()));
 
 function helloWorld() {
     throw new Exception('error');

--- a/ext/tests/disable_hook_function_validation.phpt
+++ b/ext/tests/disable_hook_function_validation.phpt
@@ -18,4 +18,4 @@ function hello(int $val) {
 var_dump(hello(1));
 ?>
 --EXPECTF--
-%sArgument #1 ($object) must be of type Exception, null given, called in %a
+%sArgument #1 ($object) must be of type Exception, null given %A

--- a/ext/tests/disable_hook_function_validation.phpt
+++ b/ext/tests/disable_hook_function_validation.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Disabling hook validation
+--DESCRIPTION--
+The post hook is invalid, because of the type-hint on $object. Runtime checking is disabled, so it is executed and
+causes a fatal runtime error.
+--EXTENSIONS--
+opentelemetry
+--INI--
+opentelemetry.validate_hook_functions=Off
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(null, 'hello', post: fn(\Exception $object, array $params, string $return): string => 'replaced');
+
+function hello(int $val) {
+    return $val;
+}
+
+var_dump(hello(1));
+?>
+--EXPECTF--
+%sArgument #1 ($object) must be of type Exception, null given, called in %a

--- a/ext/tests/disable_hook_function_validation.phpt
+++ b/ext/tests/disable_hook_function_validation.phpt
@@ -18,4 +18,4 @@ function hello(int $val) {
 var_dump(hello(1));
 ?>
 --EXPECTF--
-%sArgument #1 ($object) must be of type Exception, null given %A
+%sArgument #1 ($object) must be of type Exception, null given%a

--- a/ext/tests/invalid_post_callback_signature.phpt
+++ b/ext/tests/invalid_post_callback_signature.phpt
@@ -31,3 +31,4 @@ TestClass::test();
 --EXPECTF--
 string(3) "pre"
 string(4) "test"
+OpenTelemetry: post hook invalid signature, class=TestClass function=test

--- a/ext/tests/invalid_post_callback_signature.phpt
+++ b/ext/tests/invalid_post_callback_signature.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Test invalid post callback signature
+--DESCRIPTION--
+The invalid callback signature should not cause a fatal, so it is checked before execution. If the function signature
+is invalid, the callback will not be called.
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+OpenTelemetry\Instrumentation\hook(
+    'TestClass',
+    'test',
+    static function () {
+        var_dump('pre');
+    },
+    static function (array $params) {
+        //missing param 1 (object)
+        var_dump('post');
+    }
+);
+
+class TestClass {
+    public static function test(): void
+    {
+        var_dump('test');
+    }
+}
+
+TestClass::test();
+?>
+--EXPECTF--
+string(3) "pre"
+string(4) "test"

--- a/ext/tests/invalid_pre_callback_signature.phpt
+++ b/ext/tests/invalid_pre_callback_signature.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Test invalid pre callback signature
+--DESCRIPTION--
+The invalid callback signature should not cause a fatal, so it is checked before execution. If the function signature
+is invalid, the callback will not be called.
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+OpenTelemetry\Instrumentation\hook(
+    'TestClass',
+    'test',
+    static function (array $params, string $class, string $function, ?string $filename, ?int $lineno) {
+        //missing param 1 (object)
+        var_dump('pre');
+    },
+    static function () {
+        var_dump('post');
+    }
+);
+
+class TestClass {
+    public static function test(): void
+    {
+        var_dump('test');
+    }
+}
+
+TestClass::test();
+?>
+--EXPECTF--
+string(4) "test"
+string(4) "post"

--- a/ext/tests/invalid_pre_callback_signature_with_function.phpt
+++ b/ext/tests/invalid_pre_callback_signature_with_function.phpt
@@ -1,15 +1,16 @@
 --TEST--
-Test invalid pre callback signature
+Test invalid pre callback signature for function without class
 --DESCRIPTION--
 The invalid callback signature should not cause a fatal, so it is checked before execution. If the function signature
-is invalid, the callback will not be called and a message will be written to error_log.
+is invalid, the callback will not be called and a message will be written to error_log. Also tests logging handling of
+null class.
 --EXTENSIONS--
 opentelemetry
 --FILE--
 <?php
 OpenTelemetry\Instrumentation\hook(
-    'TestClass',
-    'test',
+    null,
+    'hello',
     static function (array $params, string $class, string $function, ?string $filename, ?int $lineno) {
         //missing param 1 (object)
         var_dump('pre');
@@ -19,16 +20,14 @@ OpenTelemetry\Instrumentation\hook(
     }
 );
 
-class TestClass {
-    public static function test(): void
-    {
-        var_dump('test');
-    }
+function hello(): void
+{
+    var_dump('hello');
 }
 
-TestClass::test();
+hello();
 ?>
 --EXPECTF--
-OpenTelemetry: pre hook invalid signature, class=TestClass function=test
-string(4) "test"
+OpenTelemetry: pre hook invalid signature, class=null function=hello
+string(5) "hello"
 string(4) "post"

--- a/ext/tests/multiple_hooks_modify_returnvalue.phpt
+++ b/ext/tests/multiple_hooks_modify_returnvalue.phpt
@@ -4,10 +4,10 @@ Check if hooks receive modified return value
 opentelemetry
 --FILE--
 <?php
-\OpenTelemetry\Instrumentation\hook(null, 'helloWorld', post: fn(mixed $object, array $params, string $return): int => ++$return);
-\OpenTelemetry\Instrumentation\hook(null, 'helloWorld', post: fn(mixed $object, array $params, string $return): int => ++$return);
+\OpenTelemetry\Instrumentation\hook(null, 'helloWorld', post: fn(mixed $object, array $params, int $return): int => ++$return);
+\OpenTelemetry\Instrumentation\hook(null, 'helloWorld', post: fn(mixed $object, array $params, int $return): int => ++$return);
 
-function helloWorld(int $val) {
+function helloWorld(int $val): int {
     return $val;
 }
 


### PR DESCRIPTION
trying to execute a hook function when the provided callback's signature does not match reality is a fatal error. Check the signature before calling, and if they do not match, do not execute the callback

Fixes: https://github.com/open-telemetry/opentelemetry-php-instrumentation/issues/81