### PR TITLE
disabling expanding args for internal functions

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -13,6 +13,7 @@ RUN apt-get update \
   && apt-get install -y \
     clang-format-18 \
     gdb \
+    gdbserver \
     valgrind
 
 ENV PHPIZE_DEPS \

--- a/ext/tests/expand_params_internal.phpt
+++ b/ext/tests/expand_params_internal.phpt
@@ -8,7 +8,7 @@ it is what causes the segfault.
 --EXTENSIONS--
 opentelemetry
 --XFAIL--
-Providing a post callback when expanding params of internal function causes segfault
+Providing a post callback when expanding params of internal function causes segfault. The behaviour is currently disabled, so instead of a segfault a message is logged to error_log.
 --FILE--
 <?php
 OpenTelemetry\Instrumentation\hook(


### PR DESCRIPTION
expanding arguments for internal functions from a pre callback causes a segfault. until we can fix it properly, disable the behaviour and log to error_log.
also remove some dead/unreachable code, and add gdbserver to the docker image since I've been using it a lot.