### PR TITLE
Update opentelemetry.stub.php

### DIFF
--- a/ext/opentelemetry.stub.php
+++ b/ext/opentelemetry.stub.php
@@ -16,7 +16,7 @@ namespace OpenTelemetry\Instrumentation;
  * @see https://github.com/open-telemetry/opentelemetry-php-instrumentation
  */
 function hook(
-    ?string $class,
+    string|null $class,
     string $function,
     ?\Closure $pre = null,
     ?\Closure $post = null,


### PR DESCRIPTION
The first parameter is mandatory. `NOTICE: PHP message: PHP Fatal error:  Uncaught ArgumentCountError: OpenTelemetry\Instrumentation\hook() expects at least 2 arguments`