### PR TITLE
adding test and doc for hooking static method

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ OpenTelemetry\Instrumentation\hook(
 
 There are more examples in the [tests directory](ext/tests/)
 
+### Static methods
+
+Note that if hooking a static class method, the first parameter to `pre` and `post` callbacks is a `string` containing the method's class name.
+
 # Modifying parameters, exceptions and return values of the observed function
 
 ## Parameters

--- a/ext/package.xml
+++ b/ext/package.xml
@@ -77,6 +77,7 @@
         <file name="return_params.phpt" role="test"/>
         <file name="return_params_internal.phpt" role="test"/>
         <file name="return_reduced_params.phpt" role="test"/>
+        <file name="static_method.phpt" role="test"/>
         <file name="unwind_exit.phpt" role="test"/>
       </dir>
     </dir>

--- a/ext/tests/static_method.phpt
+++ b/ext/tests/static_method.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Check hooking static class methods provides class name as 1st param
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(
+    Demo::class,
+    'hello',
+    function($class) {
+        var_dump($class);
+    },
+    function($class) {
+        var_dump($class);
+    }
+);
+
+class Demo {
+    public static function hello(): void
+    {
+        var_dump('hello');
+    }
+}
+
+Demo::hello();
+?>
+--EXPECT--
+string(4) "Demo"
+string(5) "hello"
+string(4) "Demo"


### PR DESCRIPTION
it's not documented anywhere what the first param for pre/post callbacks is when hooking a static class method. Adds a test and a note to the readme.