### PR TITLE
Fix segfault by checking observer_class_lookup for NULL in observer callback

### DIFF
--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -532,6 +532,15 @@ static otel_observer *resolve_observer(zend_execute_data *execute_data) {
 
 static zend_observer_fcall_handlers
 observer_fcall_init(zend_execute_data *execute_data) {
+    // This means that either RINIT has not yet been called, or RSHUTDOWN has
+    // already been called. The former can happen if another extension that is
+    // loaded before this one invokes PHP functions in its RINIT. The latter
+    // can happen if a header callback is set or when another extension invokes
+    // PHP functions in their RSHUTDOWN.
+    if (OTEL_G(observer_class_lookup) == NULL) {
+        return (zend_observer_fcall_handlers){NULL, NULL};
+    }
+
     if (op_array_extension == -1) {
         return (zend_observer_fcall_handlers){NULL, NULL};
     }


### PR DESCRIPTION
Resolves #59 and most likely also #80 

I have managed to reproduce the crash in #59 locally on PHP 8.2.10 with a minimal sample (running via Apache).
```php
<?php
function test() {}
header_register_callback('test');
```

This happens because if nothing has been written to output, `php_output_deactivate` causes `sapi_send_headers` to be called, which in turn runs the header callback. Since header callback is a PHP function, the observer callback is invoked for that. The problem is that `php_output_deactivate` was called by `php_request_shutdown` immediately after module RSHUTDOWN callbacks were called, in which `observer_class_lookup` used by our observer callback is freed and set to `NULL`.

I have confirmed that the crash in the above sample stops reproducing after this change.

Additionally, the issue in #80 seems to be caused by another extension invoking PHP code in their RINIT. Since it is possible that the other extension is earlier in the load list, thus `observer_class_lookup` is not constructed yet (it is guaranteed to not be garbage because GINIT sets it to `NULL`, so checking for `NULL` should be safe) as that is done in RINIT. This new check should fix that as well.