### PR TITLE
re-enable blackfire

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ php --ri  opentelemetry
 
 ### Conflicting extensions
 
-The OpenTelemetry extension does not play nicely with the following other extensions:
-- blackfire
+The extension can be configured to not run if a conflicting extension is installed. Currently, we
+are not aware of any such extensions.
 
 You can control conflicts via the `opentelemetry.conflicts` ini setting.
 

--- a/ext/opentelemetry.c
+++ b/ext/opentelemetry.c
@@ -76,7 +76,7 @@ ZEND_DECLARE_MODULE_GLOBALS(opentelemetry)
 
 PHP_INI_BEGIN()
 // conflicting extensions. a comma-separated list, eg "ext1,ext2"
-STD_PHP_INI_ENTRY("opentelemetry.conflicts", "blackfire", PHP_INI_ALL,
+STD_PHP_INI_ENTRY("opentelemetry.conflicts", "", PHP_INI_ALL,
                   OnUpdateString, conflicts, zend_opentelemetry_globals,
                   opentelemetry_globals)
 STD_PHP_INI_ENTRY_EX("opentelemetry.validate_hook_functions", "On", PHP_INI_ALL,

--- a/ext/opentelemetry.c
+++ b/ext/opentelemetry.c
@@ -76,9 +76,8 @@ ZEND_DECLARE_MODULE_GLOBALS(opentelemetry)
 
 PHP_INI_BEGIN()
 // conflicting extensions. a comma-separated list, eg "ext1,ext2"
-STD_PHP_INI_ENTRY("opentelemetry.conflicts", "", PHP_INI_ALL,
-                  OnUpdateString, conflicts, zend_opentelemetry_globals,
-                  opentelemetry_globals)
+STD_PHP_INI_ENTRY("opentelemetry.conflicts", "", PHP_INI_ALL, OnUpdateString,
+                  conflicts, zend_opentelemetry_globals, opentelemetry_globals)
 STD_PHP_INI_ENTRY_EX("opentelemetry.validate_hook_functions", "On", PHP_INI_ALL,
                      OnUpdateBool, validate_hook_functions,
                      zend_opentelemetry_globals, opentelemetry_globals,


### PR DESCRIPTION
a bug has been fixed which means we no longer segfault if the blackfire extension is installed. Remove the conflict, and update readme.