### PR TITLE
add pear to build

### DIFF
--- a/.github/workflows/publish-php-debug-images.yml
+++ b/.github/workflows/publish-php-debug-images.yml
@@ -44,5 +44,4 @@ jobs:
           file: docker/Dockerfile.${{ matrix.os }}
           build-args: |
             PHP_VERSION=${{ env.PHP_VERSION }}
-            PHP_CONFIG_OPTS=--enable-debug
           tags: ghcr.io/open-telemetry/opentelemetry-php-instrumentation/php:${{ matrix.php-version }}-${{ matrix.os }}-debug


### PR DESCRIPTION
dont clobber the dockerfile arg for PHP_CONFIG_OPTS, which includes --with-pear. this will allow us to pear package within the build