### PR TITLE
document SourceGuardian incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,14 @@ php --ri  opentelemetry
 
 ### Conflicting extensions
 
-The extension can be configured to not run if a conflicting extension is installed. Currently, we
-are not aware of any such extensions.
+The extension can be configured to not run if a conflicting extension is installed. The following extensions
+are known to not work when installed alongside OpenTelemetry:
 
-You can control conflicts via the `opentelemetry.conflicts` ini setting.
+* SourceGuardian
+
+If the conflicting extension is a regular PHP extension (i.e, not a
+[zend_extension](https://www.phpinternalsbook.com/php7/extensions_design/zend_extensions.html)), you can control
+conflicts via the `opentelemetry.conflicts` ini setting.
 
 If a conflicting extension is found, then the OpenTelemetry extension will disable itself:
 


### PR DESCRIPTION
Our existing conflict checking doesn't work with zend extensions, since they're loaded after normal extensions. Moving the checks to later (eg in RINIT) breaks our extension, so the best I think we can do is to just document it.

Closes: #106 