### PR TITLE
adding test for post hook type error

### DIFF
--- a/ext/package.xml
+++ b/ext/package.xml
@@ -72,6 +72,7 @@
         <file name="multiple_hooks_modify_returnvalue.phpt" role="test"/>
         <file name="post_hook_return_ignored_without_type.phpt" role="test"/>
         <file name="post_hook_throws_exception.phpt" role="test"/>
+        <file name="post_hook_type_error.phpt" role="test"/>
         <file name="reimplemented_interface.phpt" role="test"/>
         <file name="return_expanded_params.phpt" role="test"/>
         <file name="return_expanded_params_internal.phpt" role="test"/>

--- a/ext/tests/post_hook_type_error.phpt
+++ b/ext/tests/post_hook_type_error.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Check if type error in post hook is handled
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+class Foo
+{
+  public function bar(): void
+  {
+    var_dump('bar');
+  }
+}
+
+\OpenTelemetry\Instrumentation\hook(
+    Foo::class,
+    'bar',
+    fn() => var_dump('pre'),
+    fn(string $scope, array $params, mixed $returnValue, ?Throwable $throwable) => var_dump('post')); //NB invalid type for $scope
+
+try {
+  (new Foo())->bar();
+} catch(Exception) {}
+
+--EXPECTF--
+string(3) "pre"
+string(3) "bar"
+
+Warning: Foo::bar(): OpenTelemetry: post hook threw exception, class=Foo function=bar message=%sArgument #1 ($scope) must be of type string, Foo given%s

--- a/ext/tests/post_hook_type_error.phpt
+++ b/ext/tests/post_hook_type_error.phpt
@@ -22,8 +22,10 @@ try {
   (new Foo())->bar();
 } catch(Exception) {}
 
+var_dump('baz');
 --EXPECTF--
 string(3) "pre"
 string(3) "bar"
 
 Warning: Foo::bar(): OpenTelemetry: post hook threw exception, class=Foo function=bar message=%sArgument #1 ($scope) must be of type string, Foo given%s
+string(3) "baz"

--- a/ext/tests/post_hook_type_error.phpt
+++ b/ext/tests/post_hook_type_error.phpt
@@ -18,10 +18,7 @@ class Foo
     fn() => var_dump('pre'),
     fn(string $scope, array $params, mixed $returnValue, ?Throwable $throwable) => var_dump('post')); //NB invalid type for $scope
 
-try {
-  (new Foo())->bar();
-} catch(Exception) {}
-
+(new Foo())->bar();
 var_dump('baz');
 --EXPECTF--
 string(3) "pre"


### PR DESCRIPTION
if an invalid typehint is provided for first param of post callback, this would previously cause a hang. fixed by #118, this test confirms the fix works in this scenario.