### PR TITLE
Fix modifying extra parameters, limit parameter expansion

### DIFF
--- a/ext/.gitignore
+++ b/ext/.gitignore
@@ -1,4 +1,5 @@
 *.lo
+*.loT
 *.la
 .libs
 .idea/

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -289,6 +289,10 @@ static void arg_locator_initialize(otel_arg_locator *arg_locator,
     arg_locator->execute_data = execute_data;
 
     if (execute_data->func->type == ZEND_INTERNAL_FUNCTION) {
+        // For internal functions, rather than having reserved number of slots
+        // before auxiliary slots and extra ones after that, internal functions
+        // have all (and only) arguments provided by call site before auxiliary
+        // slots, and there is nothing after auxiliary slots.
         arg_locator->reserved = ZEND_CALL_NUM_ARGS(execute_data);
     } else {
         arg_locator->reserved = execute_data->func->op_array.last_var;

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -410,7 +410,7 @@ static void observer_begin(zend_execute_data *execute_data, zend_llist *hooks) {
                         args_initialized = idx + 1;
                     } else {
                         // This slot was already initialized, need to
-                        // dereference its contents before overwriting
+                        // decrement refcount before overwriting
                         zval_dtor(target);
                     }
 

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -63,7 +63,11 @@ static void func_get_args(zval *zv, zend_execute_data *ex) {
     // https://github.com/php/php-src/blob/php-8.1.0/Zend/zend_builtin_functions.c#L235
     if (arg_count) {
         array_init_size(zv, arg_count);
-        first_extra_arg = ex->func->op_array.num_args;
+        if (ex->func->type == ZEND_INTERNAL_FUNCTION) {
+            first_extra_arg = arg_count;
+        } else {
+            first_extra_arg = ex->func->op_array.num_args;
+        }
         zend_hash_real_init_packed(Z_ARRVAL_P(zv));
         ZEND_HASH_FILL_PACKED(Z_ARRVAL_P(zv)) {
             i = 0;

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -22,6 +22,18 @@ typedef struct otel_exception_state {
     const zend_op *opline;
 } otel_exception_state;
 
+typedef struct otel_arg_locator {
+    zend_execute_data *execute_data;
+    // Number of argument slots reserved in execute_data, any arguments beyond
+    // this limit will be stored after auxiliary slots
+    uint32_t reserved;
+    // Number of arguments provided at the call site. May exceed the number of
+    // arguments in the function definition
+    uint32_t provided;
+    // Number of slots between reserved and "extra" argument slots
+    uint32_t auxiliary_slots;
+} otel_arg_locator;
+
 static inline void
 func_get_this_or_called_scope(zval *zv, zend_execute_data *execute_data) {
     if (execute_data->func->op_array.scope) {
@@ -272,6 +284,31 @@ static void exception_isolation_handle_exception(zend_object *suppressed,
     OBJ_RELEASE(suppressed);
 }
 
+static void arg_locator_initialize(otel_arg_locator *arg_locator,
+                                   zend_execute_data *execute_data) {
+    arg_locator->execute_data = execute_data;
+
+    if (execute_data->func->type == ZEND_INTERNAL_FUNCTION) {
+        arg_locator->reserved = ZEND_CALL_NUM_ARGS(execute_data);
+    } else {
+        arg_locator->reserved = execute_data->func->op_array.last_var;
+    }
+
+    arg_locator->provided = ZEND_CALL_NUM_ARGS(execute_data);
+    arg_locator->auxiliary_slots = execute_data->func->op_array.T;
+}
+
+static zval *arg_locator_get_slot(otel_arg_locator *arg_locator,
+                                  uint32_t index) {
+    if (index < arg_locator->reserved) {
+        return ZEND_CALL_ARG(arg_locator->execute_data, index + 1);
+    } else if (index < arg_locator->provided) {
+        return ZEND_CALL_ARG(arg_locator->execute_data,
+                             index + arg_locator->auxiliary_slots + 1);
+    }
+    return NULL;
+}
+
 static void observer_begin(zend_execute_data *execute_data, zend_llist *hooks) {
     if (!zend_llist_count(hooks)) {
         return;
@@ -323,44 +360,79 @@ static void observer_begin(zend_execute_data *execute_data, zend_llist *hooks) {
                 zend_ulong idx;
                 zend_string *str_idx;
                 zval *val;
+                bool invalid_arg_warned = false;
+
+                otel_arg_locator arg_locator;
+                arg_locator_initialize(&arg_locator, execute_data);
+                uint32_t args_initialized = arg_locator.provided;
+
                 ZEND_HASH_FOREACH_KEY_VAL(Z_ARR(ret), idx, str_idx, val) {
                     if (str_idx != NULL) {
                         // TODO support named params
                         continue;
                     }
-                    zval *target = NULL;
-                    uint32_t arg_count = ZEND_CALL_NUM_ARGS(execute_data);
-                    if (idx >= arg_count) {
-                        if (func->type == ZEND_INTERNAL_FUNCTION) {
-                            // TODO expanding args for internal functions causes
-                            // segfault
-                            php_error_docref(
-                                NULL, E_NOTICE,
-                                "OpenTelemetry: expanding args of "
-                                "internal functions not supported");
+
+                    zval *target = arg_locator_get_slot(&arg_locator, idx);
+
+                    if (target == NULL) {
+                        if (invalid_arg_warned) {
                             continue;
                         }
-                        // TODO Extend call frame?
-                        // zend_vm_stack_extend_call_frame(&execute_data,
-                        // arg_count, idx + 1 - arg_count);
-                        for (uint32_t i = arg_count; i < idx; i++) {
-                            ZVAL_UNDEF(ZEND_CALL_ARG(execute_data, i + 1));
+
+                        php_error_docref(
+                            NULL, E_NOTICE,
+                            "OpenTelemetry: pre hook invalid argument index "
+                            "%" PRIu32 ", class=%s function=%s",
+                            idx, zval_get_chars(&params[2]),
+                            zval_get_chars(&params[3]));
+                        invalid_arg_warned = true;
+                        continue;
+                    }
+
+                    if (idx >= args_initialized) {
+                        // This slot was not initialized, need to initialize
+                        // all slots between current and the last initialized
+                        // one
+                        for (uint32_t i = args_initialized; i < idx; i++) {
+                            ZVAL_UNDEF(arg_locator_get_slot(&arg_locator, i));
                             ZEND_ADD_CALL_FLAG(execute_data,
                                                ZEND_CALL_MAY_HAVE_UNDEF);
                         }
-                        ZEND_CALL_NUM_ARGS(execute_data) = idx + 1;
-                        ZVAL_COPY(ZEND_CALL_ARG(execute_data, idx + 1), val);
+
+                        args_initialized = idx + 1;
                     } else {
-                        target = ZEND_CALL_ARG(execute_data, idx + 1);
+                        // This slot was already initialized, need to
+                        // dereference its contents before overwriting
                         zval_dtor(target);
-                        ZVAL_COPY(target, val);
-                        if (Z_TYPE(params[1]) == IS_ARRAY) {
-                            Z_TRY_ADDREF_P(val);
-                            zend_hash_index_update(Z_ARR(params[1]), idx, val);
-                        }
+                    }
+
+                    if (idx >= arg_locator.reserved && Z_REFCOUNTED_P(val)) {
+                        // If there are any "extra parameters" that are
+                        // refcounted, then this flag must be set. While we
+                        // cannot add any new extra parameter slots, this flag
+                        // may not have been present because all the values
+                        // were previously not refcounted
+                        ZEND_ADD_CALL_FLAG(execute_data,
+                                           ZEND_CALL_FREE_EXTRA_ARGS);
+                    }
+
+                    ZVAL_COPY(target, val);
+
+                    if (idx < arg_locator.provided &&
+                        Z_TYPE(params[1]) == IS_ARRAY) {
+                        // This index is present in the array provided to begin
+                        // hook, update it in that array as well
+                        Z_TRY_ADDREF_P(val);
+                        zend_hash_index_update(Z_ARR(params[1]), idx, val);
                     }
                 }
                 ZEND_HASH_FOREACH_END();
+
+                // Update provided argument count if begin hook added arguments
+                // that were not provided originally
+                if (args_initialized > arg_locator.provided) {
+                    ZEND_CALL_NUM_ARGS(execute_data) = args_initialized;
+                }
             }
         }
 

--- a/ext/package.xml
+++ b/ext/package.xml
@@ -57,6 +57,7 @@
         <file name="disable_hook_function_validation.phpt" role="test"/>
         <file name="disabled_with_conflicting_extension.phpt" role="test"/>
         <file name="expand_params.phpt" role="test"/>
+        <file name="expand_params_extra.phpt" role="test"/>
         <file name="expand_params_internal.phpt" role="test"/>
         <file name="function_closure.phpt" role="test"/>
         <file name="function_first_class_callable.phpt" role="test"/>
@@ -66,6 +67,7 @@
         <file name="invalid_post_callback_signature.phpt" role="test"/>
         <file name="invalid_pre_callback_signature.phpt" role="test"/>
         <file name="invalid_pre_callback_signature_with_function.phpt" role="test"/>
+        <file name="modify_extra_params.phpt" role="test"/>
         <file name="modify_named_params.phpt" role="test"/>
         <file name="modify_params.phpt" role="test"/>
         <file name="multiple_hooks_modify_params.phpt" role="test"/>

--- a/ext/package.xml
+++ b/ext/package.xml
@@ -68,6 +68,7 @@
         <file name="invalid_pre_callback_signature.phpt" role="test"/>
         <file name="invalid_pre_callback_signature_with_function.phpt" role="test"/>
         <file name="modify_extra_params.phpt" role="test"/>
+        <file name="modify_extra_params_internal.phpt" role="test"/>
         <file name="modify_named_params.phpt" role="test"/>
         <file name="modify_params.phpt" role="test"/>
         <file name="multiple_hooks_modify_params.phpt" role="test"/>

--- a/ext/tests/expand_params_extra.phpt
+++ b/ext/tests/expand_params_extra.phpt
@@ -1,5 +1,9 @@
 --TEST--
 Check if pre hook can expand params of function with extra parameters not provided by call site
+--DESCRIPTION--
+Extra parameters for user functions are parameters that were provided at call site but were not present in the function
+declaration. The extension only supports modifying existing ones, not adding new ones. Test that a warning is logged if
+adding new ones is attempted and that it does not crash.
 --EXTENSIONS--
 opentelemetry
 --FILE--

--- a/ext/tests/expand_params_extra.phpt
+++ b/ext/tests/expand_params_extra.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Check if pre hook can expand params of function if they are part of function definition
+Check if pre hook can expand params of function with extra parameters not provided by call site
 --EXTENSIONS--
 opentelemetry
 --FILE--
@@ -8,7 +8,7 @@ OpenTelemetry\Instrumentation\hook(
     null,
     'helloWorld',
     pre: function($instance, array $params) {
-        return [$params[0], 'b'];
+        return [$params[0], 'b', 'c', 'd'];
     },
     post: fn() => null
 );
@@ -18,7 +18,8 @@ function helloWorld($a, $b) {
 }
 helloWorld('a');
 ?>
---EXPECT--
+--EXPECTF--
+Notice: helloWorld(): OpenTelemetry: pre hook invalid argument index 2, class=null function=helloWorld in %s
 array(2) {
   [0]=>
   string(1) "a"

--- a/ext/tests/expand_params_internal.phpt
+++ b/ext/tests/expand_params_internal.phpt
@@ -23,7 +23,7 @@ OpenTelemetry\Instrumentation\hook(
 var_dump(array_slice([1,2,3], 1));
 ?>
 --EXPECTF--
-Notice: array_slice(): OpenTelemetry: expanding args of internal functions not supported in %s on line %d
+Notice: array_slice(): OpenTelemetry: pre hook invalid argument index 2, class=null function=array_slice in %s
 array(2) {
   [0]=>
   int(2)

--- a/ext/tests/modify_extra_params.phpt
+++ b/ext/tests/modify_extra_params.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Check if pre hook can modify extra parameters
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+OpenTelemetry\Instrumentation\hook(
+    null,
+    'helloWorld',
+    pre: function($instance, array $params) {
+        return ['b0', 'b1', 'b2', 'b3', 'b4', 'b5', 'b6'];
+    },
+    post: fn() => null
+);
+
+function helloWorld($a, $b) {
+    var_dump(func_get_args());
+}
+helloWorld('a0', 'a1', 'a2', 'a3', 'a4', 'a5', 'a6');
+?>
+--EXPECT--
+array(7) {
+  [0]=>
+  string(2) "b0"
+  [1]=>
+  string(2) "b1"
+  [2]=>
+  string(2) "b2"
+  [3]=>
+  string(2) "b3"
+  [4]=>
+  string(2) "b4"
+  [5]=>
+  string(2) "b5"
+  [6]=>
+  string(2) "b6"
+}

--- a/ext/tests/modify_extra_params.phpt
+++ b/ext/tests/modify_extra_params.phpt
@@ -1,5 +1,9 @@
 --TEST--
 Check if pre hook can modify extra parameters
+--DESCRIPTION--
+Extra parameters for user functions are parameters that were provided at call site but were not present in the function
+declaration. It is important to test how these are handled because they are stored differently in memory and it should
+be checked that the extension handles them correctly.
 --EXTENSIONS--
 opentelemetry
 --FILE--

--- a/ext/tests/modify_extra_params_internal.phpt
+++ b/ext/tests/modify_extra_params_internal.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Check if pre hook trying to modify extra params of internal functions crashes
+--DESCRIPTION--
+Modifying extra parameters of internal functions is actually not useful at all since providing too many parameters
+to an internal function always causes an Error to be thrown anyway. However, the test is still needed to make sure it
+does not crash.
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80200) die('skip requires PHP >= 8.2'); ?>
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+OpenTelemetry\Instrumentation\hook(
+    null,
+    'array_slice',
+    pre: function(null $instance, array $params) {
+        return [$params[0], $params[1], 2, false, 'a'];
+    },
+    post: fn() => null
+);
+
+try {
+    var_dump(array_slice([1,2,3], 1, 1, false, 'a'));
+} catch (Throwable $t) {
+    var_dump($t->getMessage());
+}
+?>
+--EXPECT--
+string(50) "array_slice() expects at most 4 arguments, 5 given"

--- a/ext/tests/return_expanded_params_internal.phpt
+++ b/ext/tests/return_expanded_params_internal.phpt
@@ -21,7 +21,7 @@ opentelemetry
 var_dump(array_slice(['a', 'b', 'c'], 1));
 ?>
 --EXPECTF--
-Notice: array_slice(): OpenTelemetry: expanding args of internal functions not supported in %s on line %d
+Notice: array_slice(): OpenTelemetry: pre hook invalid argument index 2, class=null function=array_slice in %s
 array(2) {
   [0]=>
   string(1) "b"


### PR DESCRIPTION
Some additional context here: https://github.com/open-telemetry/opentelemetry-php/issues/1155#issuecomment-1905288940

Limited the maximum index of parameters provided by begin hook to below `max(defined_param_count, callsite_param_count)`. Within this limit, the call frame already has all the slots present and the call frame size does not need to be extended. Extension would not possible here because it might require reallocating the call frame to a different location and the current call frame pointer is stored in local variables of functions that called our observer.

Additionally, fixed writing to "extra" parameter slots (parameters that were provided at call site but not part of function definition). Previously, it was assumed that all parameters are stored continuously in memory, but there is actually a gap between "reserved" parameter slots and extra parameter slots, which needs to be added when addressing extra parameters. This previously caused a crash, some modified parameters not actually being modified and/or additional side effects due to overwriting memory meant for other purposes.

When dealing with extra parameters, it was also necessary to add the `ZEND_CALL_FREE_EXTRA_ARGS` in some cases, because it was only set if at least one of the original extra parameters was refcounted. Thus if replacing a non-refcounted extra parameter with a refcounted one, this has to be set.

Note that this does not change the behavior for internal functions - for those still only the arguments provided at call site can be modified, and you cannot provide an argument that is part of function definition (as per documentation) but not originally provided. While testing what happens when attempting to call internal functions with too many parameters, I did however discover that `func_get_args` handled that case incorrectly and crashed, which is also fixed here.

For an example of memory layout of parameters, check the comment linked at the beginning.