### PR TITLE
Fix crash by unregistering INI in MSHUTDOWN instead of RSHUTDOWN

### DIFF
--- a/ext/opentelemetry.c
+++ b/ext/opentelemetry.c
@@ -112,7 +112,6 @@ PHP_RINIT_FUNCTION(opentelemetry) {
 }
 
 PHP_RSHUTDOWN_FUNCTION(opentelemetry) {
-    UNREGISTER_INI_ENTRIES();
     observer_globals_cleanup();
 
     return SUCCESS;
@@ -126,6 +125,12 @@ PHP_MINIT_FUNCTION(opentelemetry) {
     if (!OTEL_G(disabled)) {
         opentelemetry_observer_init(INIT_FUNC_ARGS_PASSTHRU);
     }
+
+    return SUCCESS;
+}
+
+PHP_MSHUTDOWN_FUNCTION(opentelemetry) {
+    UNREGISTER_INI_ENTRIES();
 
     return SUCCESS;
 }
@@ -149,7 +154,7 @@ zend_module_entry opentelemetry_module_entry = {
     "opentelemetry",
     ext_functions,
     PHP_MINIT(opentelemetry),
-    NULL,
+    PHP_MSHUTDOWN(opentelemetry),
     PHP_RINIT(opentelemetry),
     PHP_RSHUTDOWN(opentelemetry),
     PHP_MINFO(opentelemetry),

--- a/ext/package.xml
+++ b/ext/package.xml
@@ -63,6 +63,7 @@
         <file name="function_internal.phpt" role="test"/>
         <file name="hooks_throw_exception.phpt" role="test"/>
         <file name="hooks_throw_exception_for_failed_call.phpt" role="test"/>
+        <file name="ini_set.phpt" role="test"/>
         <file name="invalid_post_callback_signature.phpt" role="test"/>
         <file name="invalid_pre_callback_signature.phpt" role="test"/>
         <file name="invalid_pre_callback_signature_with_function.phpt" role="test"/>

--- a/ext/tests/ini_set.phpt
+++ b/ext/tests/ini_set.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Check if process exits gracefully after using ini_set with an opentelemtry option
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+ini_set('opentelemetry.conflicts', 'test');
+var_dump('done');
+?>
+--EXPECT--
+string(4) "done"

--- a/ext/tests/ini_set.phpt
+++ b/ext/tests/ini_set.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Check if process exits gracefully after using ini_set with an opentelemtry option
+Check if process exits gracefully after using ini_set with an opentelemetry option
 --EXTENSIONS--
 opentelemetry
 --FILE--


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-php/issues/1195

Currently INI options are unregistered in `RSHUTDOWN`, which is incorrect and will cause a crash on shutdown if `ini_set` has been used in code. Moved it to `MSHUTDOWN`.