### PR TITLE
Fix exception raised by `php_error_docref` that hangs the process in hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
+.vscode/
 *.tgz
 

--- a/ext/opentelemetry.c
+++ b/ext/opentelemetry.c
@@ -19,7 +19,7 @@ static int check_conflict(HashTable *registry, const char *extension_name) {
     zend_module_entry *module_entry;
     ZEND_HASH_FOREACH_PTR(registry, module_entry) {
         if (strcmp(module_entry->name, extension_name) == 0) {
-            php_error_docref(NULL, E_NOTICE,
+            php_error_docref(NULL, E_CORE_WARNING,
                              "Conflicting extension found (%s), OpenTelemetry "
                              "extension will be disabled",
                              extension_name);

--- a/ext/opentelemetry.c
+++ b/ext/opentelemetry.c
@@ -19,7 +19,7 @@ static int check_conflict(HashTable *registry, const char *extension_name) {
     zend_module_entry *module_entry;
     ZEND_HASH_FOREACH_PTR(registry, module_entry) {
         if (strcmp(module_entry->name, extension_name) == 0) {
-            php_error_docref(NULL, E_CORE_WARNING,
+            php_error_docref(NULL, E_NOTICE,
                              "Conflicting extension found (%s), OpenTelemetry "
                              "extension will be disabled",
                              extension_name);

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -304,7 +304,7 @@ static void exception_isolation_handle_exception(zend_object *suppressed,
         zend_read_property_ex(exception_base, suppressed,
                               ZSTR_KNOWN(ZEND_STR_MESSAGE), 1, &return_value);
 
-    php_error_docref(NULL, E_WARNING,
+    php_error_docref(NULL, E_CORE_WARNING,
                      "OpenTelemetry: %s threw exception,"
                      " class=%s function=%s message=%s",
                      type, zval_get_chars(class_name),
@@ -378,7 +378,7 @@ static void observer_begin(zend_execute_data *execute_data, zend_llist *hooks) {
         fci.retval = &ret;
 
         if (!is_valid_signature(fci, fcc)) {
-            php_error_docref(NULL, E_WARNING,
+            php_error_docref(NULL, E_CORE_WARNING,
                              "OpenTelemetry: pre hook invalid signature,"
                              " class=%s function=%s",
                              (Z_TYPE_P(&params[2]) == IS_NULL)
@@ -409,7 +409,7 @@ static void observer_begin(zend_execute_data *execute_data, zend_llist *hooks) {
 
                         if (idx == (uint32_t)-1) {
                             php_error_docref(
-                                NULL, E_NOTICE,
+                                NULL, E_CORE_WARNING,
                                 "OpenTelemetry: pre hook unknown "
                                 "named arg %s, class=%s function=%s",
                                 ZSTR_VAL(str_idx), zval_get_chars(&params[2]),
@@ -426,7 +426,7 @@ static void observer_begin(zend_execute_data *execute_data, zend_llist *hooks) {
                         }
 
                         php_error_docref(
-                            NULL, E_NOTICE,
+                            NULL, E_CORE_WARNING,
                             "OpenTelemetry: pre hook invalid argument index "
                             "%" PRIu32 ", class=%s function=%s",
                             idx, zval_get_chars(&params[2]),
@@ -545,7 +545,7 @@ static void observer_end(zend_execute_data *execute_data, zval *retval,
         fci.retval = &ret;
 
         if (!is_valid_signature(fci, fcc)) {
-            php_error_docref(NULL, E_WARNING,
+            php_error_docref(NULL, E_CORE_WARNING,
                              "OpenTelemetry: post hook invalid signature, "
                              "class=%s function=%s",
                              (Z_TYPE_P(&params[4]) == IS_NULL)

--- a/ext/package.xml
+++ b/ext/package.xml
@@ -77,6 +77,7 @@
         <file name="function_internal.phpt" role="test"/>
         <file name="hooks_throw_exception.phpt" role="test"/>
         <file name="hooks_throw_exception_for_failed_call.phpt" role="test"/>
+        <file name="hooks_throw_exception_error_handler.phpt" role="test"/>
         <file name="ini_set.phpt" role="test"/>
         <file name="invalid_post_callback_signature.phpt" role="test"/>
         <file name="invalid_pre_callback_signature.phpt" role="test"/>

--- a/ext/tests/expand_params_extra.phpt
+++ b/ext/tests/expand_params_extra.phpt
@@ -23,7 +23,7 @@ function helloWorld($a, $b) {
 helloWorld('a');
 ?>
 --EXPECTF--
-Notice: helloWorld(): OpenTelemetry: pre hook invalid argument index 2, class=null function=helloWorld in %s
+Warning: helloWorld(): OpenTelemetry: pre hook invalid argument index 2, class=null function=helloWorld in %s
 array(2) {
   [0]=>
   string(1) "a"

--- a/ext/tests/expand_params_internal.phpt
+++ b/ext/tests/expand_params_internal.phpt
@@ -23,7 +23,7 @@ OpenTelemetry\Instrumentation\hook(
 var_dump(array_slice([1,2,3], 1));
 ?>
 --EXPECTF--
-Notice: array_slice(): OpenTelemetry: pre hook invalid argument index 2, class=null function=array_slice in %s
+Warning: array_slice(): OpenTelemetry: pre hook invalid argument index 2, class=null function=array_slice in %s
 array(2) {
   [0]=>
   int(2)

--- a/ext/tests/hooks_throw_exception_error_handler.phpt
+++ b/ext/tests/hooks_throw_exception_error_handler.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Check if exceptions thrown in hooks work if custom error handler throws
+--DESCRIPTION--
+If the extension internally logs errors/warnings in a way that set_error_handler gets invoked, then any
+exceptions/errors may cause the process to crash or hang if raising a throwable was not safe at that moment.
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+set_error_handler(function (int $errno, string $message) {
+    throw new \Error('Throw from error handler: ' . $message);
+});
+function helloWorld() {
+    throw new \Error('test');
+}
+\OpenTelemetry\Instrumentation\hook(
+    null,
+    'helloWorld',
+    pre: static function () : void {
+        throw new \Exception('pre');
+    }
+);
+helloWorld();
+?>
+--EXPECTF--
+Warning: helloWorld(): OpenTelemetry: pre hook threw exception, class=null function=helloWorld message=pre in %s
+
+Fatal error: Uncaught Error: test in %s
+Stack trace:
+#0 %s: helloWorld()
+#1 {main}
+  thrown in %s

--- a/ext/tests/modify_named_params_invalid.phpt
+++ b/ext/tests/modify_named_params_invalid.phpt
@@ -20,7 +20,7 @@ function hello($one = null, $two = null, $three = null) {
 hello('a', 'b', 'c');
 ?>
 --EXPECTF--
-Notice: hello(): OpenTelemetry: pre hook unknown named arg four, class=null function=hello in %s
+Warning: hello(): OpenTelemetry: pre hook unknown named arg four, class=null function=hello in %s
 array(3) {
   [0]=>
   string(1) "a"

--- a/ext/tests/return_expanded_params_internal.phpt
+++ b/ext/tests/return_expanded_params_internal.phpt
@@ -21,7 +21,7 @@ opentelemetry
 var_dump(array_slice(['a', 'b', 'c'], 1));
 ?>
 --EXPECTF--
-Notice: array_slice(): OpenTelemetry: pre hook invalid argument index 2, class=null function=array_slice in %s
+Warning: array_slice(): OpenTelemetry: pre hook invalid argument index 2, class=null function=array_slice in %s
 array(2) {
   [0]=>
   string(1) "b"


### PR DESCRIPTION
Use `E_CORE_WARNING` error type to prevent PHP function from being executed when calling `php_error_docref` in observer pre/post hook handling. Reasoning is explained below:

Calling `php_error_docref` will call the PHP function provided with `set_error_handler` for most error types. This error handler may throw exceptions, and cause the situation where begin handler finishes with an exception being active. This causes a hang or crash similar to how it happened when exceptions from pre hook itself weren't cleared.

The options to fix this is to either use an error type that cannot call user error handler function, or clear the exception *again* after calling `php_error_docref`. However, it seems that some error handlers actually intentionally throw an exception, so it could be caught by application code and then logged. For example:
https://github.com/codeigniter4/CodeIgniter4/blob/3734bbba29cd7fb07399c4886e6637c8d73bd209/system/Debug/Exceptions.php#L202

Since some error handlers do not actually even intend to log the error, as is intended when we call `php_error_docref`, it makes more sense to make sure the user error handler is not called in the first place. This can be done by using error type `E_CORE_WARNING`, as error handling code in PHP considers this type to be "unsafe to be handled by PHP code", therefore no PHP code can be called to handle this (it is logged as if `set_error_handler` was never called), and no exception will be left up, thus it fixes the hang/crash.