### PR TITLE
fix clang-format installation

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 WORKDIR /usr/src
 
 #clang-format, gdb, valgrind
@@ -7,11 +7,11 @@ RUN apt-get update \
     curl \
     gnupg2 \
   && curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
-  && echo "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye main" >> /etc/apt/sources.list \
-  && echo "deb-src http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye main" >> /etc/apt/sources.list \
+  && echo "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm main" >> /etc/apt/sources.list \
+  && echo "deb-src http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm main" >> /etc/apt/sources.list \
   && apt-get update \
   && apt-get install -y \
-    clang-format-18 \
+    clang-format \
     gdb \
     gdbserver \
     valgrind

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -7,11 +7,11 @@ RUN apt-get update \
     curl \
     gnupg2 \
   && curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
-  && echo "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm main" >> /etc/apt/sources.list \
-  && echo "deb-src http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm main" >> /etc/apt/sources.list \
+  && echo "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-18 main" >> /etc/apt/sources.list \
+  && echo "deb-src http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-18 main" >> /etc/apt/sources.list \
   && apt-get update \
   && apt-get install -y \
-    clang-format \
+    clang-format-18 \
     gdb \
     gdbserver \
     valgrind

--- a/ext/format.sh
+++ b/ext/format.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-clang-format -i *.c *.h
+clang-format-18 -i *.c *.h

--- a/ext/format.sh
+++ b/ext/format.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-clang-format-18 -i *.c *.h
+clang-format -i *.c *.h


### PR DESCRIPTION
the dev image had broken because clang-format-18 was no longer available. switching to clang-format seems to work, and upgrade to debian bookworm for good measure.