### PR TITLE
Enable strict warnings

### DIFF
--- a/ext/config.m4
+++ b/ext/config.m4
@@ -90,5 +90,5 @@ if test "$PHP_OPENTELEMETRY" != "no"; then
   dnl In case of no dependencies
   AC_DEFINE(HAVE_OPENTELEMETRY, 1, [ Have opentelemetry support ])
 
-  PHP_NEW_EXTENSION(opentelemetry, opentelemetry.c otel_observer.c, $ext_shared)
+  PHP_NEW_EXTENSION(opentelemetry, opentelemetry.c otel_observer.c, $ext_shared,, "-Wall -Wextra -Werror -Wno-unused-parameter")
 fi


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-php/issues/1230

Options `-Wall -Wextra` enable almost all known warnings and `-Werror` makes any warning fail the build. `-Wno-unused-parameter` excludes the warning of unused parameters, which cannot be avoided anyway due to PHP macros introducing those.

It appears that current code did not trigger any warnings other than the `unused-parameter` one (which at least confirmed that enabling warnings worked), so nothing in the source needed fixing.