### PR TITLE
adding failing test for returning cloned modified object from post hook

### DIFF
--- a/ext/package.xml
+++ b/ext/package.xml
@@ -82,6 +82,7 @@
         <file name="multiple_hooks_modify_params.phpt" role="test"/>
         <file name="multiple_hooks_modify_returnvalue.phpt" role="test"/>
         <file name="post_hook_return_ignored_without_type.phpt" role="test"/>
+        <file name="post_hook_returns_cloned_modified_object.phpt" role="test"/>
         <file name="post_hook_throws_exception.phpt" role="test"/>
         <file name="post_hook_type_error.phpt" role="test"/>
         <file name="reimplemented_interface.phpt" role="test"/>

--- a/ext/tests/post_hook_returns_cloned_modified_object.phpt
+++ b/ext/tests/post_hook_returns_cloned_modified_object.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Check if post hook can returned modified clone
+----DESCRIPTION--
+A different object might be returned than the one provided to post hook. For example, PSR-7 messages are immutable and modifying
+one creates a new instance.
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+class Foo
+{
+    public ?string $a = null;
+    public function __construct(string $a = null)
+    {
+        $this->a = $a;
+    }
+    public function modify(string $value): Foo
+    {
+        $new = clone($this);
+        $new->a = $value;
+
+        return $new;
+    }
+}
+
+\OpenTelemetry\Instrumentation\hook(null, 'getFoo', null, function(null $obj, array $params, Foo $foo): Foo {
+    return $foo->modify('b');
+});
+
+function getFoo(): Foo {
+    return new Foo('a'); //providing a constructor arg or not sometimes changes error to a reported memory leak
+}
+
+var_dump(getFoo());
+?>
+--EXPECT--
+object(Foo)#2 (1) {
+  ["a"]=>
+  string(1) "b"
+}

--- a/ext/tests/post_hook_returns_cloned_modified_object.phpt
+++ b/ext/tests/post_hook_returns_cloned_modified_object.phpt
@@ -23,7 +23,7 @@ class Foo
     }
 }
 
-\OpenTelemetry\Instrumentation\hook(null, 'getFoo', null, function(null $obj, array $params, Foo $foo): Foo {
+\OpenTelemetry\Instrumentation\hook(null, 'getFoo', null, function($obj, array $params, Foo $foo): Foo {
     return $foo->modify('b');
 });
 

--- a/ext/tests/post_hook_returns_cloned_modified_object.phpt
+++ b/ext/tests/post_hook_returns_cloned_modified_object.phpt
@@ -28,13 +28,13 @@ class Foo
 });
 
 function getFoo(): Foo {
-    return new Foo('a'); //providing a constructor arg or not sometimes changes error to a reported memory leak
+    return new Foo('a');
 }
 
 var_dump(getFoo());
 ?>
---EXPECT--
-object(Foo)#2 (1) {
+--EXPECTF--
+object(Foo)#%d (1) {
   ["a"]=>
   string(1) "b"
 }


### PR DESCRIPTION
Cloning, then modifying and returning the return value from a post hook can cause either a segfault or a reported memory leak (it seems random, see comment in test).
The use-case for this is changing an immutable object (such as a PSR-7 message) from a post hook.