### PR TITLE
Fix leak and double free in post hook return value handling

### DIFF
--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -657,7 +657,9 @@ static void observer_end(zend_execute_data *execute_data, zval *retval,
                 if (execute_data->return_value) {
                     zval_ptr_dtor(execute_data->return_value);
                     ZVAL_COPY(execute_data->return_value, &ret);
-                    params[2] = ret;
+                    zval_ptr_dtor(&params[2]);
+                    ZVAL_COPY_VALUE(&params[2], &ret);
+                    ZVAL_UNDEF(&ret);
                 }
             }
         }


### PR DESCRIPTION
Fixes failing test case in https://github.com/open-telemetry/opentelemetry-php-instrumentation/pull/135

When post hook handler overrode the return value, it copied the contents of its `zval` to the parameter array passed to next hooks for the same function, so nested hooks would see updated return value.

However, it did not decrement the reference to the old value, plus it created a situation where the new value would be stored in both `ret` and `params[2]`, which both get destroyed separately in the end, making it attempt to free something that's already freed.

Changed it so that 1) `zval_ptr_dtor` is called on old value 2) after new value is moved to `params[2]`, `ret` is set to "undefined" so that destroying it in the end becomes a no-op.