### PR TITLE
ensure save_state->opline is initialized

### DIFF
--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -264,6 +264,7 @@ static void exception_isolation_start(otel_exception_state *save_state) {
         save_state->opline = execute_data->opline;
     } else {
         save_state->has_opline = false;
+        save_state->opline = NULL;
     }
 }
 


### PR DESCRIPTION
This resolves a warning against gcc10 which was stopping compilation with that compiler. Thanks to @mlocati for identifying the issue and proposing a fix, but this fix proposed by @agoallikmaa seems more portable.

Fixes: https://github.com/open-telemetry/opentelemetry-php/issues/1260
Replaces: https://github.com/open-telemetry/opentelemetry-php-instrumentation/pull/138