### PR TITLE
fixing WithSpanHandler namespace

### DIFF
--- a/ext/opentelemetry.c
+++ b/ext/opentelemetry.c
@@ -92,11 +92,11 @@ STD_PHP_INI_ENTRY_EX("opentelemetry.attr_hooks_enabled", "Off", PHP_INI_ALL,
                      zend_opentelemetry_globals, opentelemetry_globals,
                      zend_ini_boolean_displayer_cb)
 STD_PHP_INI_ENTRY("opentelemetry.attr_pre_handler_function",
-                  "Opentelemetry\\API\\Instrumentation\\WithSpanHandler::pre",
+                  "OpenTelemetry\\API\\Instrumentation\\WithSpanHandler::pre",
                   PHP_INI_ALL, OnUpdateString, pre_handler_function_fqn,
                   zend_opentelemetry_globals, opentelemetry_globals)
 STD_PHP_INI_ENTRY("opentelemetry.attr_post_handler_function",
-                  "Opentelemetry\\API\\Instrumentation\\WithSpanHandler::post",
+                  "OpenTelemetry\\API\\Instrumentation\\WithSpanHandler::post",
                   PHP_INI_ALL, OnUpdateString, post_handler_function_fqn,
                   zend_opentelemetry_globals, opentelemetry_globals)
 PHP_INI_END()

--- a/ext/opentelemetry.stub.php
+++ b/ext/opentelemetry.stub.php
@@ -7,7 +7,7 @@ namespace OpenTelemetry\Instrumentation;
 /**
  * @param string|null $class The (optional) hooked function's class. Null for a global/built-in function.
  * @param string $function The hooked function's name.
- * @param \Closure|null $pre function($class, array $params, string $class, string $function, ?string $filename, ?int $lineno, ?array $span_args, ?array $span_attributes): $params
+ * @param \Closure|null $pre function($class, array $params, ?string $class, string $function, ?string $filename, ?int $lineno, ?array $span_args, ?array $span_attributes): $params
  *        You may optionally return modified parameters.
  * @param \Closure|null $post function($class, array $params, $returnValue, ?Throwable $exception): $returnValue
  *        You may optionally return modified return value.

--- a/ext/opentelemetry_arginfo.h
+++ b/ext/opentelemetry_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: aa29142596154400c530f1194a7f29fbb9036929 */
+ * Stub hash: b656d042f34f83d9cc4896db217aff36ba902df4 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(
     arginfo_OpenTelemetry_Instrumentation_hook, 0, 2, _IS_BOOL, 0)

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -611,6 +611,8 @@ static void observer_begin(zend_execute_data *execute_data, zend_llist *hooks) {
         zend_fcall_info_cache fcc = empty_fcall_info_cache;
         if (UNEXPECTED(zend_fcall_info_init((zval *)element->data, 0, &fci,
                                             &fcc, NULL, NULL) != SUCCESS)) {
+            php_error_docref(NULL, E_WARNING,
+                             "Failed to initialize pre hook callable");
             continue;
         }
 
@@ -785,6 +787,8 @@ static void observer_end(zend_execute_data *execute_data, zval *retval,
         zend_fcall_info_cache fcc = empty_fcall_info_cache;
         if (UNEXPECTED(zend_fcall_info_init((zval *)element->data, 0, &fci,
                                             &fcc, NULL, NULL) != SUCCESS)) {
+            php_error_docref(NULL, E_WARNING,
+                             "Failed to initialize post hook callable");
             continue;
         }
 

--- a/ext/tests/with_span/autoloaded_handler.phpt
+++ b/ext/tests/with_span/autoloaded_handler.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Check if WithSpanHandler can be provided by an autoloader
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80100) die('skip requires PHP >= 8.1'); ?>
+--EXTENSIONS--
+opentelemetry
+--INI--
+opentelemetry.attr_hooks_enabled = On
+--FILE--
+<?php
+include dirname(__DIR__) . '/mocks/WithSpan.php';
+
+use OpenTelemetry\API\Instrumentation\WithSpan;
+use OpenTelemetry\API\Instrumentation\WithSpanHandler;
+
+function my_autoloader($class) {
+    var_dump("autoloading: " . $class);
+    $file = dirname(__DIR__) . '/mocks/WithSpanHandler.php';
+    if (file_exists($file)) {
+        include $file;
+    } else {
+        die("could not autoload: ".$class);
+    }
+}
+spl_autoload_register('my_autoloader');
+
+class TestClass
+{
+    #[WithSpan]
+    function sayFoo(): void
+    {
+        var_dump('foo');
+    }
+}
+
+$c = new TestClass();
+$c->sayFoo();
+?>
+--EXPECT--
+string(62) "autoloading: OpenTelemetry\API\Instrumentation\WithSpanHandler"
+string(3) "pre"
+string(3) "foo"
+string(4) "post"

--- a/ext/tests/with_span/handler_not_found.phpt
+++ b/ext/tests/with_span/handler_not_found.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Check if warning emitted when default handler does not exist
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80100) die('skip requires PHP >= 8.1'); ?>
+--EXTENSIONS--
+opentelemetry
+--INI--
+opentelemetry.attr_hooks_enabled = On
+--FILE--
+<?php
+namespace OpenTelemetry\API\Instrumentation;
+
+include dirname(__DIR__) . '/mocks/WithSpan.php';
+use OpenTelemetry\API\Instrumentation\WithSpan;
+
+class TestClass
+{
+    #[WithSpan]
+    function sayFoo(): void
+    {
+        var_dump('foo');
+    }
+}
+
+$c = new TestClass();
+$c->sayFoo();
+?>
+--EXPECTF--
+
+Warning: OpenTelemetry\API\Instrumentation\TestClass::sayFoo(): Failed to initialize pre hook callable in %s
+string(3) "foo"
+
+Warning: OpenTelemetry\API\Instrumentation\TestClass::sayFoo(): Failed to initialize post hook callable in %s


### PR DESCRIPTION
- fix the namespace so that composer autoloader can find the class, and also add warnings when a handler is not found or could not be loaded
- note that pre handler class param is optional (and not provided for functions)
- add some tests for autoloading and missing handler