### PR TITLE
fix 2 tests for PHP 8.4

### DIFF
--- a/ext/tests/post_hook_returns_cloned_modified_object.phpt
+++ b/ext/tests/post_hook_returns_cloned_modified_object.phpt
@@ -10,7 +10,7 @@ opentelemetry
 class Foo
 {
     public ?string $a = null;
-    public function __construct(string $a = null)
+    public function __construct(string|null $a = null)
     {
         $this->a = $a;
     }

--- a/ext/tests/span_attribute/function_params_non_simple.phpt
+++ b/ext/tests/span_attribute/function_params_non_simple.phpt
@@ -34,7 +34,7 @@ foo(
     null,
 );
 ?>
---EXPECT--
+--EXPECTF--
 string(3) "pre"
 array(4) {
   ["one"]=>
@@ -46,7 +46,7 @@ array(4) {
   object(stdClass)#1 (0) {
   }
   ["three"]=>
-  object(Closure)#2 (0) {
+  object(Closure)#2 (%d) {%A
   }
   ["four"]=>
   NULL


### PR DESCRIPTION
Attempting to build for Alpinelinux and have following tests failed

- https://php.watch/rfcs/deprecate-implicitly-nullable-types
- https://github.com/php/php-src/pull/13550

