### PR TITLE
dont emit warnings by default

### DIFF
--- a/ext/opentelemetry.c
+++ b/ext/opentelemetry.c
@@ -91,6 +91,9 @@ STD_PHP_INI_ENTRY_EX("opentelemetry.attr_hooks_enabled", "Off", PHP_INI_ALL,
                      OnUpdateBool, attr_hooks_enabled,
                      zend_opentelemetry_globals, opentelemetry_globals,
                      zend_ini_boolean_displayer_cb)
+STD_PHP_INI_ENTRY_EX("opentelemetry.display_warnings", "Off", PHP_INI_ALL,
+                     OnUpdateBool, display_warnings, zend_opentelemetry_globals,
+                     opentelemetry_globals, zend_ini_boolean_displayer_cb)
 STD_PHP_INI_ENTRY("opentelemetry.attr_pre_handler_function",
                   "OpenTelemetry\\API\\Instrumentation\\WithSpanHandler::pre",
                   PHP_INI_ALL, OnUpdateString, pre_handler_function_fqn,

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -975,7 +975,8 @@ static otel_observer *resolve_observer(zend_execute_data *execute_data) {
     }
     bool has_withspan_attribute = func_has_withspan_attribute(execute_data);
 
-    if (OTEL_G(attr_hooks_enabled) == false && has_withspan_attribute) {
+    if (OTEL_G(attr_hooks_enabled) == false && has_withspan_attribute &&
+        OTEL_G(display_warnings) == true) {
         php_error_docref(NULL, E_CORE_WARNING,
                          "OpenTelemetry: WithSpan attribute found but "
                          "attribute hooks disabled");

--- a/ext/php_opentelemetry.h
+++ b/ext/php_opentelemetry.h
@@ -14,6 +14,7 @@ ZEND_BEGIN_MODULE_GLOBALS(opentelemetry)
     int disabled; // module disabled? (eg due to conflicting extension loaded)
     int allow_stack_extension;
     int attr_hooks_enabled; // attribute hooking enabled?
+    int display_warnings;
     char *pre_handler_function_fqn;
     char *post_handler_function_fqn;
 ZEND_END_MODULE_GLOBALS(opentelemetry)

--- a/ext/tests/with_span/disable.phpt
+++ b/ext/tests/with_span/disable.phpt
@@ -6,6 +6,7 @@ Check if attribute hooks can be disabled by config
 opentelemetry
 --INI--
 opentelemetry.attr_hooks_enabled = Off
+opentelemetry.display_warnings = On
 --FILE--
 <?php
 namespace OpenTelemetry\API\Instrumentation;


### PR DESCRIPTION
adds a new ini entry, opentelemetry.display_warnings, default=off, to control whether warnings are emitted.

Closes: https://github.com/open-telemetry/opentelemetry-php/issues/1476