### PR TITLE
Add observeAll() to make it possible to instrument all function calls

### DIFF
--- a/ext/opentelemetry.c
+++ b/ext/opentelemetry.c
@@ -118,6 +118,20 @@ PHP_FUNCTION(OpenTelemetry_Instrumentation_hook) {
     RETURN_BOOL(add_observer(class_name, function_name, pre, post));
 }
 
+// Main implementation
+PHP_FUNCTION(OpenTelemetry_Instrumentation_observeAll) {
+    zval *pre = NULL;
+    zval *post = NULL;
+
+    ZEND_PARSE_PARAMETERS_START(0, 2)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_OBJECT_OF_CLASS_OR_NULL(pre, zend_ce_closure)
+        Z_PARAM_OBJECT_OF_CLASS_OR_NULL(post, zend_ce_closure)
+    ZEND_PARSE_PARAMETERS_END();
+
+    RETURN_BOOL(add_wildcard_observer(pre, post));
+}
+
 PHP_RINIT_FUNCTION(opentelemetry) {
 #if defined(ZTS) && defined(COMPILE_DL_OPENTELEMETRY)
     ZEND_TSRMLS_CACHE_UPDATE();

--- a/ext/opentelemetry.stub.php
+++ b/ext/opentelemetry.stub.php
@@ -21,3 +21,17 @@ function hook(
     ?\Closure $pre = null,
     ?\Closure $post = null,
 ): bool {}
+
+/**
+ * @param \Closure|null $pre function($class, array $params, ?string $class, string $function, ?string $filename, ?int $lineno, ?array $span_args, ?array $span_attributes): $params
+ *        You may optionally return modified parameters.
+ * @param \Closure|null $post function($class, array $params, $returnValue, ?Throwable $exception): $returnValue
+ *        You may optionally return modified return value.
+ * @return bool Whether the observer was successfully added
+ *
+ * @see https://github.com/open-telemetry/opentelemetry-php-instrumentation
+ */
+function observeAll(
+    ?\Closure $pre = null,
+    ?\Closure $post = null,
+): bool {}

--- a/ext/opentelemetry_arginfo.h
+++ b/ext/opentelemetry_arginfo.h
@@ -1,16 +1,25 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b656d042f34f83d9cc4896db217aff36ba902df4 */
+ * Stub hash: a909b08f77c774d518ce9fbf5975f4f65a79235c */
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(
-    arginfo_OpenTelemetry_Instrumentation_hook, 0, 2, _IS_BOOL, 0)
-    ZEND_ARG_TYPE_INFO(0, class, IS_STRING, 1)
-    ZEND_ARG_TYPE_INFO(0, function, IS_STRING, 0)
-    ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, pre, Closure, 1, "null")
-    ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, post, Closure, 1, "null")
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_OpenTelemetry_Instrumentation_hook, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, class, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, function, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, pre, Closure, 1, "null")
+	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, post, Closure, 1, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_FUNCTION(OpenTelemetry_Instrumentation_hook);
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_OpenTelemetry_Instrumentation_observeAll, 0, 0, _IS_BOOL, 0)
+	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, pre, Closure, 1, "null")
+	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, post, Closure, 1, "null")
+ZEND_END_ARG_INFO()
 
-static const zend_function_entry ext_functions[] = {ZEND_NS_FALIAS(
-    "OpenTelemetry\\Instrumentation", hook, OpenTelemetry_Instrumentation_hook,
-    arginfo_OpenTelemetry_Instrumentation_hook) ZEND_FE_END};
+
+ZEND_FUNCTION(OpenTelemetry_Instrumentation_hook);
+ZEND_FUNCTION(OpenTelemetry_Instrumentation_observeAll);
+
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_NS_FALIAS("OpenTelemetry\\Instrumentation", hook, OpenTelemetry_Instrumentation_hook, arginfo_OpenTelemetry_Instrumentation_hook)
+	ZEND_NS_FALIAS("OpenTelemetry\\Instrumentation", observeAll, OpenTelemetry_Instrumentation_observeAll, arginfo_OpenTelemetry_Instrumentation_observeAll)
+	ZEND_FE_END
+};

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -1000,7 +1000,6 @@ static otel_observer *resolve_observer(zend_execute_data *execute_data) {
 
         otel_observer *observer = create_observer();
         copy_observer_deep(OTEL_G(wildcard_observer), observer);
-        zend_hash_next_index_insert_ptr(OTEL_G(observer_aggregates), observer);
         return observer;
     }
 
@@ -1068,7 +1067,6 @@ static otel_observer *resolve_observer(zend_execute_data *execute_data) {
     }
     otel_observer *observer = create_observer();
     copy_observer(&observer_instance, observer);
-    zend_hash_next_index_insert_ptr(OTEL_G(observer_aggregates), observer);
 
     return observer;
 }
@@ -1092,6 +1090,8 @@ observer_fcall_init(zend_execute_data *execute_data) {
     if (!observer) {
         return (zend_observer_fcall_handlers){NULL, NULL};
     }
+
+    zend_hash_next_index_insert_ptr(OTEL_G(observer_aggregates), observer);
 
     ZEND_OP_ARRAY_EXTENSION(&execute_data->func->op_array, op_array_extension) =
         observer;

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -967,26 +967,6 @@ static zval create_attribute_observer_handler(char *fn) {
     return callable;
 }
 
-static void copy_observer_deep(otel_observer *source, otel_observer *destination) {
-    // Initialize new lists
-    zend_llist_init(&destination->pre_hooks, sizeof(zval), (llist_dtor_func_t)zval_ptr_dtor, 0);
-    zend_llist_init(&destination->post_hooks, sizeof(zval), (llist_dtor_func_t)zval_ptr_dtor, 0);
-
-    // Deep copy pre hooks with proper reference counting
-    for (zend_llist_element *element = source->pre_hooks.head; element; element = element->next) {
-        zval tmp;
-        ZVAL_COPY(&tmp, (zval *)element->data);
-        zend_llist_add_element(&destination->pre_hooks, &tmp);
-    }
-
-    // Deep copy post hooks with proper reference counting
-    for (zend_llist_element *element = source->post_hooks.head; element; element = element->next) {
-        zval tmp;
-        ZVAL_COPY(&tmp, (zval *)element->data);
-        zend_llist_add_element(&destination->post_hooks, &tmp);
-    }
-}
-
 static otel_observer *resolve_observer(zend_execute_data *execute_data) {
     zend_function *fbc = execute_data->func;
     if (!fbc->common.function_name) {
@@ -1082,22 +1062,18 @@ observer_fcall_init(zend_execute_data *execute_data) {
     if (OTEL_G(wildcard_observer) &&
         (zend_llist_count(&OTEL_G(wildcard_observer)->pre_hooks) ||
          zend_llist_count(&OTEL_G(wildcard_observer)->post_hooks))) {
-        if (observer) {
-            // Merge wildcard hooks into existing observer
-            for (zend_llist_element *element = OTEL_G(wildcard_observer)->pre_hooks.head; element; element = element->next) {
-                zval tmp;
-                ZVAL_COPY(&tmp, (zval *)element->data);
-                zend_llist_add_element(&observer->pre_hooks, &tmp);
-            }
-            for (zend_llist_element *element = OTEL_G(wildcard_observer)->post_hooks.head; element; element = element->next) {
-                zval tmp;
-                ZVAL_COPY(&tmp, (zval *)element->data);
-                zend_llist_add_element(&observer->post_hooks, &tmp);
-            }
-        } else {
-            // Create new observer from wildcard
+        if (!observer) {
             observer = create_observer();
-            copy_observer_deep(OTEL_G(wildcard_observer), observer);
+        }
+
+        // Merge wildcard hooks into observer
+        for (zend_llist_element *element = OTEL_G(wildcard_observer)->pre_hooks.head; element; element = element->next) {
+            zval_add_ref((zval *)&element->data);
+            zend_llist_add_element(&observer->pre_hooks, &element->data);
+        }
+        for (zend_llist_element *element = OTEL_G(wildcard_observer)->post_hooks.head; element; element = element->next) {
+            zval_add_ref((zval *)&element->data);
+            zend_llist_add_element(&observer->post_hooks, &element->data);
         }
     }
 

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -1155,18 +1155,13 @@ bool add_wildcard_observer(zval *pre_hook, zval *post_hook) {
         return false;
     }
 
-    // If both hooks are NULL, disable the wildcard observer
+    // If both hooks are NULL, disable all wildcard observers.
     if (!pre_hook && !post_hook) {
         if (OTEL_G(wildcard_observer)) {
             free_observer(OTEL_G(wildcard_observer));
             OTEL_G(wildcard_observer) = NULL;
         }
         return true;
-    }
-
-    // Return false if a observer has already been created.
-    if (OTEL_G(wildcard_observer)) {
-        return false;
     }
 
     if (!OTEL_G(wildcard_observer)) {

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -863,7 +863,9 @@ static void observer_begin_handler(zend_execute_data *execute_data) {
         return;
     }
 
+    OTEL_G(in_hook) = true;
     observer_begin(execute_data, &observer->pre_hooks);
+    OTEL_G(in_hook) = false;
 }
 
 static void observer_end_handler(zend_execute_data *execute_data,
@@ -874,7 +876,9 @@ static void observer_end_handler(zend_execute_data *execute_data,
         return;
     }
 
+    OTEL_G(in_hook) = true;
     observer_end(execute_data, retval, &observer->post_hooks);
+    OTEL_G(in_hook) = false;
 }
 
 static void free_observer(otel_observer *observer) {
@@ -964,6 +968,11 @@ static zval create_attribute_observer_handler(char *fn) {
 }
 
 static otel_observer *resolve_observer(zend_execute_data *execute_data) {
+    // Skip if we're currently executing a hook
+    if (OTEL_G(in_hook)) {
+        return NULL;
+    }
+
     // Check for wildcard observer first
     if (OTEL_G(wildcard_observer) &&
         (zend_llist_count(&OTEL_G(wildcard_observer)->pre_hooks) ||
@@ -1174,6 +1183,8 @@ void observer_globals_init(void) {
         zend_hash_init(OTEL_G(observer_aggregates), 8, NULL,
                        destroy_observer_lookup, 0);
     }
+
+    OTEL_G(in_hook) = false;
 }
 
 void observer_globals_cleanup(void) {
@@ -1197,6 +1208,8 @@ void observer_globals_cleanup(void) {
         free_observer(OTEL_G(wildcard_observer));
         OTEL_G(wildcard_observer) = NULL;
     }
+
+    OTEL_G(in_hook) = false;
 }
 
 void opentelemetry_observer_init(INIT_FUNC_ARGS) {

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -1165,8 +1165,17 @@ bool add_wildcard_observer(zval *pre_hook, zval *post_hook) {
         return false;
     }
 
-    // Return false if neither hook is provided
+    // If both hooks are NULL, disable the wildcard observer
     if (!pre_hook && !post_hook) {
+        if (OTEL_G(wildcard_observer)) {
+            free_observer(OTEL_G(wildcard_observer));
+            OTEL_G(wildcard_observer) = NULL;
+        }
+        return true;
+    }
+
+    // Return false if a observer has already been created.
+    if (OTEL_G(wildcard_observer)) {
         return false;
     }
 

--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -988,11 +988,6 @@ static void copy_observer_deep(otel_observer *source, otel_observer *destination
 }
 
 static otel_observer *resolve_observer(zend_execute_data *execute_data) {
-    // Skip if we're currently executing a hook
-    if (OTEL_G(in_hook)) {
-        return NULL;
-    }
-
     // Check for wildcard observer first
     if (OTEL_G(wildcard_observer) &&
         (zend_llist_count(&OTEL_G(wildcard_observer)->pre_hooks) ||
@@ -1079,6 +1074,11 @@ observer_fcall_init(zend_execute_data *execute_data) {
     // can happen if a header callback is set or when another extension invokes
     // PHP functions in their RSHUTDOWN.
     if (OTEL_G(observer_class_lookup) == NULL) {
+        return (zend_observer_fcall_handlers){NULL, NULL};
+    }
+
+    // Skip if we're currently executing a hook
+    if (OTEL_G(in_hook)) {
         return (zend_observer_fcall_handlers){NULL, NULL};
     }
 

--- a/ext/otel_observer.h
+++ b/ext/otel_observer.h
@@ -8,5 +8,6 @@ void observer_globals_cleanup(void);
 
 bool add_observer(zend_string *cn, zend_string *fn, zval *pre_hook,
                   zval *post_hook);
+bool add_wildcard_observer(zval *pre_hook, zval *post_hook);
 
 #endif // OPENTELEMETRY_OBSERVER_H

--- a/ext/php_opentelemetry.h
+++ b/ext/php_opentelemetry.h
@@ -15,6 +15,7 @@ ZEND_BEGIN_MODULE_GLOBALS(opentelemetry)
     HashTable *observer_function_lookup;
     HashTable *observer_aggregates;
     otel_observer *wildcard_observer;
+    bool in_hook;
     int validate_hook_functions;
     char *conflicts;
     int disabled; // module disabled? (eg due to conflicting extension loaded)

--- a/ext/php_opentelemetry.h
+++ b/ext/php_opentelemetry.h
@@ -5,10 +5,16 @@
 extern zend_module_entry opentelemetry_module_entry;
 #define phpext_opentelemetry_ptr &opentelemetry_module_entry
 
+typedef struct otel_observer {
+    zend_llist pre_hooks;
+    zend_llist post_hooks;
+} otel_observer;
+
 ZEND_BEGIN_MODULE_GLOBALS(opentelemetry)
     HashTable *observer_class_lookup;
     HashTable *observer_function_lookup;
     HashTable *observer_aggregates;
+    otel_observer *wildcard_observer;
     int validate_hook_functions;
     char *conflicts;
     int disabled; // module disabled? (eg due to conflicting extension loaded)

--- a/ext/tests/observe_all.phpt
+++ b/ext/tests/observe_all.phpt
@@ -1,0 +1,56 @@
+--TEST--
+Check wildcard observer captures all function calls
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+$calls = [];
+
+\OpenTelemetry\Instrumentation\observeAll(
+    function($object, $args, $scope, $function) use (&$calls) {
+        $calls[] = "pre:" . ($scope ?? "global") . "::" . $function;
+    },
+    function($object, $args, $retval, $exception, $scope, $function) use (&$calls) {
+        $calls[] = "post:" . ($scope ?? "global") . "::" . $function;
+    }
+);
+
+function test_function() {
+    return "test";
+}
+
+class Demo {
+    public static function static_method() {
+        return "static";
+    }
+
+    public function instance_method() {
+        return "instance";
+    }
+}
+
+// Test regular function
+test_function();
+
+// Test static method
+Demo::static_method();
+
+// Test instance method
+$demo = new Demo();
+$demo->instance_method();
+
+\OpenTelemetry\Instrumentation\observeAll();
+
+// Sort and output calls for consistent testing
+sort($calls);
+foreach($calls as $call) {
+    echo $call . "\n";
+}
+?>
+--EXPECT--
+post:Demo::instance_method
+post:Demo::static_method
+post:global::test_function
+pre:Demo::instance_method
+pre:Demo::static_method
+pre:global::test_function

--- a/ext/tests/observe_all_mixed_hook.phpt
+++ b/ext/tests/observe_all_mixed_hook.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Check observeAll and hook working together
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+$calls = [];
+
+// Set up specific hook
+\OpenTelemetry\Instrumentation\hook(
+    null,
+    'test_function',
+    function($object, $args, $scope, $function) use (&$calls) {
+        $calls[] = "specific:" . $function;
+    },
+    null
+);
+
+// Set up wildcard observer
+\OpenTelemetry\Instrumentation\observeAll(
+    function($object, $args, $scope, $function) use (&$calls) {
+        if ($function !== 'var_dump') {
+            $calls[] = "wildcard:" . $function;
+        }
+    },
+    null
+);
+
+// Test function should trigger both observers
+function test_function() {
+    return "test";
+}
+
+test_function();
+
+\OpenTelemetry\Instrumentation\observeAll();
+
+sort($calls);
+var_dump($calls);
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  string(22) "specific:test_function"
+  [1]=>
+  string(22) "wildcard:test_function"
+}

--- a/ext/tests/observe_all_multi.phpt
+++ b/ext/tests/observe_all_multi.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Check wildcard observer single instance behavior
+Check wildcard observer multi instance behavior
 --EXTENSIONS--
 opentelemetry
 --FILE--
@@ -36,7 +36,7 @@ var_dump($calls);
 // Reset calls array
 $calls = [];
 
-// Disable observer should succeed
+// Disable all observers should succeed
 $result3 = \OpenTelemetry\Instrumentation\observeAll();
 var_dump($result3);
 
@@ -64,10 +64,12 @@ var_dump($calls);
 ?>
 --EXPECT--
 bool(true)
-bool(false)
-array(1) {
+bool(true)
+array(2) {
   [0]=>
   string(15) "observer1:test1"
+  [1]=>
+  string(15) "observer2:test1"
 }
 bool(true)
 array(0) {

--- a/ext/tests/observe_all_simple.phpt
+++ b/ext/tests/observe_all_simple.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Simple: Check wildcard observer captures all function calls
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+
+\OpenTelemetry\Instrumentation\observeAll(
+    function($a, $args, $scope, $function) use (&$calls) {
+        print "PRE\n";
+    },
+    function($b, $args, $retval, $exception, $scope, $function) use (&$calls) {
+        print "POST\n";
+    }
+);
+
+function test_function() {
+    return "test";
+}
+
+// Test regular function
+test_function();
+
+?>
+--EXPECT--
+PRE
+POST

--- a/ext/tests/observe_all_single.phpt
+++ b/ext/tests/observe_all_single.phpt
@@ -1,0 +1,79 @@
+--TEST--
+Check wildcard observer single instance behavior
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+$calls = [];
+
+// First observer should succeed
+$result1 = \OpenTelemetry\Instrumentation\observeAll(
+    function($object, $args, $scope, $function) use (&$calls) {
+        if ($function !== 'var_dump') {  // Ignore var_dump calls
+            $calls[] = "observer1:" . $function;
+        }
+    },
+    null
+);
+var_dump($result1);
+
+// Second observer should fail
+$result2 = \OpenTelemetry\Instrumentation\observeAll(
+    function($object, $args, $scope, $function) use (&$calls) {
+        if ($function !== 'var_dump') {
+            $calls[] = "observer2:" . $function;
+        }
+    },
+    null
+);
+var_dump($result2);
+
+// Test first observer is still working
+function test1() { }
+test1();
+var_dump($calls);
+
+// Reset calls array
+$calls = [];
+
+// Disable observer should succeed
+$result3 = \OpenTelemetry\Instrumentation\observeAll();
+var_dump($result3);
+
+// Test no calls are recorded after disable
+function test2() { }
+test2();
+var_dump($calls);
+
+// New observer after disable should succeed
+$result4 = \OpenTelemetry\Instrumentation\observeAll(
+    function($object, $args, $scope, $function) use (&$calls) {
+        if ($function !== 'var_dump') {
+            $calls[] = "observer3:" . $function;
+        }
+    },
+    null
+);
+var_dump($result4);
+
+// Test new observer is working
+function test3() { }
+test3();
+var_dump($calls);
+
+?>
+--EXPECT--
+bool(true)
+bool(false)
+array(1) {
+  [0]=>
+  string(15) "observer1:test1"
+}
+bool(true)
+array(0) {
+}
+bool(true)
+array(1) {
+  [0]=>
+  string(15) "observer3:test3"
+}


### PR DESCRIPTION
This adds an observeAll() function, which works in parallel to registered hooks.

I wanted to test what the overhead of a PHP based xhprof-compatible profiler would be in comparison to xhprof and xhprof without any processing (just the zend_execute_ex overhead).

Note: Claude 3.5 sonnet helped implement this.

--

### Some notes

- Several global observers can be active at a time
- Passing null for both hooks disables all global observers