### PR TITLE
Add windows static build support

### DIFF
--- a/ext/config.w32
+++ b/ext/config.w32
@@ -5,5 +5,5 @@ ARG_ENABLE('opentelemetry', 'opentelemetry support', 'no');
 if (PHP_OPENTELEMETRY != 'no') {
     AC_DEFINE('HAVE_OPENTELEMETRY', 1, 'opentelemetry support enabled');
 
-    EXTENSION('opentelemetry', 'opentelemetry.c otel_observer.c', '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
+    EXTENSION('opentelemetry', 'opentelemetry.c otel_observer.c', PHP_OPENTELEMETRY_SHARED, '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
 }

--- a/ext/opentelemetry.c
+++ b/ext/opentelemetry.c
@@ -138,6 +138,10 @@ PHP_RSHUTDOWN_FUNCTION(opentelemetry) {
 }
 
 PHP_MINIT_FUNCTION(opentelemetry) {
+#if defined(ZTS) && defined(COMPILE_DL_OPENTELEMETRY)
+    ZEND_TSRMLS_CACHE_UPDATE();
+#endif
+
     REGISTER_INI_ENTRIES();
 
     check_conflicts();
@@ -166,9 +170,6 @@ PHP_MINFO_FUNCTION(opentelemetry) {
 }
 
 PHP_GINIT_FUNCTION(opentelemetry) {
-#if defined(ZTS) && defined(COMPILE_DL_OPENTELEMETRY)
-    ZEND_TSRMLS_CACHE_UPDATE();
-#endif
     ZEND_SECURE_ZERO(opentelemetry_globals, sizeof(*opentelemetry_globals));
 }
 

--- a/ext/opentelemetry.c
+++ b/ext/opentelemetry.c
@@ -166,6 +166,9 @@ PHP_MINFO_FUNCTION(opentelemetry) {
 }
 
 PHP_GINIT_FUNCTION(opentelemetry) {
+#if defined(ZTS) && defined(COMPILE_DL_OPENTELEMETRY)
+    ZEND_TSRMLS_CACHE_UPDATE();
+#endif
     ZEND_SECURE_ZERO(opentelemetry_globals, sizeof(*opentelemetry_globals));
 }
 


### PR DESCRIPTION
This patch will allow opentelemetry compiling with php-src statically on Windows.