### PR TITLE
fix test for php 8.5

### DIFF
--- a/ext/tests/multiple_hooks_modify_params.phpt
+++ b/ext/tests/multiple_hooks_modify_params.phpt
@@ -11,7 +11,7 @@ function helloWorld($a) {
     var_dump($a);
 }
 
-helloWorld('a');
+helloWorld(1);
 ?>
 --EXPECT--
-string(1) "c"
+int(3)


### PR DESCRIPTION
This test just started failing against php nightly, because it uses a technique that will be deprecated:

Deprecated: Increment on non-numeric string is deprecated, use str_increment() instead in /home/runner/work/opentelemetry-php-instrumentation/opentelemetry-php-instrumentation/ext/tests/multiple_hooks_modify_params.php

Update the test to use numerics instead of a string.

ref: https://github.com/php/php-src/commit/93716bece48b0dd1943d6dc72cd160790feee8da