### PR TITLE
adding test for const span_kind

### DIFF
--- a/ext/package.xml
+++ b/ext/package.xml
@@ -118,6 +118,7 @@
           <file name="disable.phpt" role="test"/>
           <file name="handler_not_found.phpt" role="test"/>
           <file name="invalid_callback.phpt" role="test"/>
+          <file name="span_kind_const.phpt" role="test"/>
         </dir>
         <dir name="span_attribute">
           <file name="attribute_on_interface.phpt" role="test"/>

--- a/ext/tests/mocks/WithSpanHandlerDumpAll.php
+++ b/ext/tests/mocks/WithSpanHandlerDumpAll.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace OpenTelemetry\API\Instrumentation;
+
+class WithSpanHandler
+{
+    public static function pre(): void
+    {
+        var_dump('pre');
+        var_dump(func_get_args());
+    }
+    public static function post(): void
+    {
+        var_dump('post');
+    }
+}

--- a/ext/tests/with_span/span_kind_const.phpt
+++ b/ext/tests/with_span/span_kind_const.phpt
@@ -1,0 +1,58 @@
+--TEST--
+Check if span_kind can be passed via a const
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80100) die('skip requires PHP >= 8.1'); ?>
+--EXTENSIONS--
+opentelemetry
+--INI--
+opentelemetry.attr_hooks_enabled = On
+--FILE--
+<?php
+namespace OpenTelemetry\API\Instrumentation;
+
+include dirname(__DIR__) . '/mocks/WithSpan.php';
+include dirname(__DIR__) . '/mocks/WithSpanHandlerDumpAll.php';
+include dirname(__DIR__) . '/mocks/SpanAttribute.php';
+use OpenTelemetry\API\Instrumentation\WithSpan;
+use OpenTelemetry\API\Instrumentation\SpanAttribute;
+
+interface SpanKind
+{
+    public const KIND_PRODUCER = 3;
+}
+
+#[WithSpan(span_kind: SpanKind::KIND_PRODUCER)]
+function foo(): void
+{
+    var_dump('foo');
+}
+
+foo();
+?>
+--EXPECTF--
+string(3) "pre"
+array(8) {
+  [0]=>
+  NULL
+  [1]=>
+  array(0) {
+  }
+  [2]=>
+  NULL
+  [3]=>
+  string(37) "OpenTelemetry\API\Instrumentation\foo"
+  [4]=>
+  string(%d) "%s/tests/with_span/span_kind_const.php"
+  [5]=>
+  int(16)
+  [6]=>
+  array(1) {
+    ["span_kind"]=>
+    int(3)
+  }
+  [7]=>
+  array(0) {
+  }
+}
+string(3) "foo"
+string(4) "post"


### PR DESCRIPTION
explicitly test that a const (eg on an interface) can be used to set span_kind in a WithSpan attribute