### PR TITLE
Add 48 new PHPT tests to improve test coverage

### DIFF
--- a/ext/tests/conflicts_empty_string.phpt
+++ b/ext/tests/conflicts_empty_string.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Check no conflict when conflicts is empty string
+--EXTENSIONS--
+opentelemetry
+--INI--
+opentelemetry.conflicts=
+--FILE--
+<?php
+var_dump(extension_loaded('opentelemetry'));
+var_dump(\OpenTelemetry\Instrumentation\hook(null, 'test_func', fn() => var_dump('PRE')));
+
+function test_func() {
+    var_dump('CALL');
+}
+
+test_func();
+?>
+--EXPECT--
+bool(true)
+bool(true)
+string(3) "PRE"
+string(4) "CALL"

--- a/ext/tests/conflicts_multiple_extensions.phpt
+++ b/ext/tests/conflicts_multiple_extensions.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Check conflict detection with multiple extensions in conflicts list
+--EXTENSIONS--
+opentelemetry
+--INI--
+opentelemetry.conflicts=nonexistent,Core
+--FILE--
+<?php
+?>
+--EXPECTF--
+Notice: PHP Startup: Conflicting extension found (Core), OpenTelemetry extension will be disabled in %s

--- a/ext/tests/conflicts_no_match.phpt
+++ b/ext/tests/conflicts_no_match.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Check no conflict when listed extensions are not loaded
+--EXTENSIONS--
+opentelemetry
+--INI--
+opentelemetry.conflicts=nonexistent1,nonexistent2
+--FILE--
+<?php
+var_dump(extension_loaded('opentelemetry'));
+$ret = \OpenTelemetry\Instrumentation\hook(null, 'test_func', fn() => var_dump('PRE'));
+
+function test_func() {
+    var_dump('CALL');
+}
+
+test_func();
+?>
+--EXPECT--
+bool(true)
+string(3) "PRE"
+string(4) "CALL"

--- a/ext/tests/conflicts_spaces.phpt
+++ b/ext/tests/conflicts_spaces.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Check conflict detection with spaces as separators
+--EXTENSIONS--
+opentelemetry
+--INI--
+opentelemetry.conflicts=nonexistent Core
+--FILE--
+<?php
+?>
+--EXPECTF--
+Notice: PHP Startup: Conflicting extension found (Core), OpenTelemetry extension will be disabled in %s

--- a/ext/tests/expand_params_no_stack_extension.phpt
+++ b/ext/tests/expand_params_no_stack_extension.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Check that expanding params without allow_stack_extension produces warning
+--EXTENSIONS--
+opentelemetry
+--INI--
+opentelemetry.allow_stack_extension=Off
+--FILE--
+<?php
+OpenTelemetry\Instrumentation\hook(
+    null,
+    'helloWorld',
+    pre: function($instance, array $params) {
+        return [$params[0], 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+    },
+    post: fn() => null
+);
+
+function helloWorld($a, $b) {
+    var_dump(func_get_args());
+}
+helloWorld('a');
+?>
+--EXPECTF--
+Warning: helloWorld(): OpenTelemetry: pre hook invalid argument index %d - stack extension must be enabled with opentelemetry.allow_stack_extension option, class=null function=helloWorld in %s on line %d
+array(%d) {
+  [0]=>
+  string(1) "a"
+  [1]=>
+  string(1) "b"
+}

--- a/ext/tests/hook_case_insensitive.phpt
+++ b/ext/tests/hook_case_insensitive.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Check hooks are matched case-insensitively
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(null, 'HelloWorld', fn() => var_dump('PRE'), fn() => var_dump('POST'));
+
+function helloworld() {
+    var_dump('CALL');
+}
+
+helloworld();
+?>
+--EXPECT--
+string(3) "PRE"
+string(4) "CALL"
+string(4) "POST"

--- a/ext/tests/hook_class_case_insensitive.phpt
+++ b/ext/tests/hook_class_case_insensitive.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Check class hooks are matched case-insensitively
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook('DEMO', 'HELLO', fn() => var_dump('PRE'), fn() => var_dump('POST'));
+
+class Demo {
+    public static function hello(): void
+    {
+        var_dump('CALL');
+    }
+}
+
+Demo::hello();
+?>
+--EXPECT--
+string(3) "PRE"
+string(4) "CALL"
+string(4) "POST"

--- a/ext/tests/hook_class_not_yet_defined.phpt
+++ b/ext/tests/hook_class_not_yet_defined.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Check hook registered before class is defined still works
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook('LaterClass', 'hello', fn() => var_dump('PRE'), fn() => var_dump('POST'));
+
+// Class defined after hook registration
+class LaterClass {
+    public static function hello(): void
+    {
+        var_dump('CALL');
+    }
+}
+
+LaterClass::hello();
+?>
+--EXPECT--
+string(3) "PRE"
+string(4) "CALL"
+string(4) "POST"

--- a/ext/tests/hook_declaring_scope.phpt
+++ b/ext/tests/hook_declaring_scope.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Check declaring scope is provided for class method hooks
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(
+    'ParentClass',
+    'hello',
+    function($obj, array $params, ?string $class, string $function) {
+        var_dump('declaring_scope: ' . $class);
+    }
+);
+
+class ParentClass {
+    public function hello(): void {}
+}
+
+class ChildClass extends ParentClass {}
+
+$c = new ChildClass();
+$c->hello();
+?>
+--EXPECT--
+string(28) "declaring_scope: ParentClass"

--- a/ext/tests/hook_deep_inheritance.phpt
+++ b/ext/tests/hook_deep_inheritance.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Check hooks work with deep class hierarchy (3+ levels)
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(
+    'GrandParent',
+    'hello',
+    function($obj) {
+        var_dump('pre: ' . get_class($obj));
+    },
+    function($obj) {
+        var_dump('post: ' . get_class($obj));
+    }
+);
+
+class GrandParent {
+    public function hello(): void
+    {
+        var_dump('hello');
+    }
+}
+
+class ParentClass extends GrandParent {}
+
+class ChildClass extends ParentClass {}
+
+$c = new ChildClass();
+$c->hello();
+?>
+--EXPECT--
+string(15) "pre: ChildClass"
+string(5) "hello"
+string(16) "post: ChildClass"

--- a/ext/tests/hook_disabled_extension.phpt
+++ b/ext/tests/hook_disabled_extension.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Check hooks do not fire when extension is disabled by conflict
+--EXTENSIONS--
+opentelemetry
+--INI--
+opentelemetry.conflicts=Core
+--FILE--
+<?php
+var_dump(\OpenTelemetry\Instrumentation\hook(null, 'hello', fn() => var_dump('PRE')));
+
+function hello() {
+    var_dump('CALL');
+}
+
+hello();
+?>
+--EXPECTF--
+Notice: PHP Startup: Conflicting extension found (Core), OpenTelemetry extension will be disabled in %s
+bool(false)
+string(4) "CALL"

--- a/ext/tests/hook_function_not_yet_defined.phpt
+++ b/ext/tests/hook_function_not_yet_defined.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Check hook registered before function is defined still works
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(null, 'laterFunction', fn() => var_dump('PRE'), fn() => var_dump('POST'));
+
+// Function defined after hook registration
+function laterFunction() {
+    var_dump('CALL');
+}
+
+laterFunction();
+?>
+--EXPECT--
+string(3) "PRE"
+string(4) "CALL"
+string(4) "POST"

--- a/ext/tests/hook_function_variadic.phpt
+++ b/ext/tests/hook_function_variadic.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Check hook on function with variadic parameters
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(
+    null,
+    'helloWorld',
+    function($obj, array $params) {
+        var_dump(count($params));
+    },
+    function($obj, array $params, mixed $ret) {
+        var_dump(count($params));
+    }
+);
+
+function helloWorld(string ...$args) {
+    return implode(',', $args);
+}
+
+helloWorld('a', 'b', 'c', 'd');
+?>
+--EXPECT--
+int(4)
+int(4)

--- a/ext/tests/hook_function_with_default_params.phpt
+++ b/ext/tests/hook_function_with_default_params.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Check hook on function with default parameters
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(
+    null,
+    'helloWorld',
+    function($obj, array $params) {
+        var_dump($params);
+    }
+);
+
+function helloWorld(string $a, string $b = 'default_b', string $c = 'default_c') {
+    var_dump($a, $b, $c);
+}
+
+helloWorld('value_a');
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  string(7) "value_a"
+}
+string(7) "value_a"
+string(9) "default_b"
+string(9) "default_c"

--- a/ext/tests/hook_inherited_method.phpt
+++ b/ext/tests/hook_inherited_method.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Check hooking parent class method fires for child class
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(
+    'ParentClass',
+    'hello',
+    function($obj, array $params, ?string $class, string $function) {
+        var_dump($class);
+    },
+    function($obj, array $params, mixed $ret, ?Throwable $e, ?string $class, string $function) {
+        var_dump($class);
+    }
+);
+
+class ParentClass {
+    public function hello(): void
+    {
+        var_dump('hello');
+    }
+}
+
+class ChildClass extends ParentClass {}
+
+$c = new ChildClass();
+$c->hello();
+?>
+--EXPECT--
+string(11) "ParentClass"
+string(5) "hello"
+string(11) "ParentClass"

--- a/ext/tests/hook_instance_method.phpt
+++ b/ext/tests/hook_instance_method.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Check hooking instance method provides object as 1st param
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(
+    Demo::class,
+    'hello',
+    function($obj) {
+        var_dump(get_class($obj));
+    },
+    function($obj) {
+        var_dump(get_class($obj));
+    }
+);
+
+class Demo {
+    public function hello(): void
+    {
+        var_dump('hello');
+    }
+}
+
+$d = new Demo();
+$d->hello();
+?>
+--EXPECT--
+string(4) "Demo"
+string(5) "hello"
+string(4) "Demo"

--- a/ext/tests/hook_interface_method.phpt
+++ b/ext/tests/hook_interface_method.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Check hooking interface method fires for implementing class
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(
+    'MyInterface',
+    'hello',
+    function($obj, array $params, ?string $class, string $function) {
+        var_dump('pre: ' . get_class($obj));
+    },
+    function($obj, array $params, mixed $ret, ?Throwable $e, ?string $class, string $function) {
+        var_dump('post: ' . get_class($obj));
+    }
+);
+
+interface MyInterface {
+    public function hello(): void;
+}
+
+class MyClass implements MyInterface {
+    public function hello(): void
+    {
+        var_dump('hello');
+    }
+}
+
+$c = new MyClass();
+$c->hello();
+?>
+--EXPECT--
+string(12) "pre: MyClass"
+string(5) "hello"
+string(13) "post: MyClass"

--- a/ext/tests/hook_internal_filename_null.phpt
+++ b/ext/tests/hook_internal_filename_null.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Check filename and lineno are null for internal functions
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80200) die('skip requires PHP >= 8.2'); ?>
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(
+    null,
+    'array_map',
+    function($obj, array $params, ?string $class, string $function, ?string $filename, ?int $lineno) {
+        var_dump($filename);
+        var_dump($lineno);
+    }
+);
+
+array_map('strtoupper', ['hello']);
+?>
+--EXPECT--
+NULL
+NULL

--- a/ext/tests/hook_internal_method.phpt
+++ b/ext/tests/hook_internal_method.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Check hooks work on internal class methods
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80200) die('skip requires PHP >= 8.2'); ?>
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(
+    'DateTime',
+    'format',
+    fn() => var_dump('PRE'),
+    fn() => var_dump('POST')
+);
+
+$dt = new DateTime('2023-01-01');
+$result = $dt->format('Y');
+var_dump($result);
+?>
+--EXPECT--
+string(3) "PRE"
+string(4) "POST"
+string(4) "2023"

--- a/ext/tests/hook_invalid_arguments.phpt
+++ b/ext/tests/hook_invalid_arguments.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Check hook() with invalid argument types
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+// Missing function_name (too few args)
+try {
+    \OpenTelemetry\Instrumentation\hook(null);
+} catch (ArgumentCountError $e) {
+    var_dump('too few args caught');
+}
+
+// Non-closure for pre hook
+try {
+    \OpenTelemetry\Instrumentation\hook(null, 'test', 'not_a_closure');
+} catch (TypeError $e) {
+    var_dump('type error caught');
+}
+?>
+--EXPECT--
+string(19) "too few args caught"
+string(17) "type error caught"

--- a/ext/tests/hook_multiple_functions.phpt
+++ b/ext/tests/hook_multiple_functions.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Check hooks on multiple different functions work independently
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(null, 'funcA', fn() => var_dump('pre-A'));
+\OpenTelemetry\Instrumentation\hook(null, 'funcB', fn() => var_dump('pre-B'));
+
+function funcA() { var_dump('A'); }
+function funcB() { var_dump('B'); }
+
+funcA();
+funcB();
+funcA();
+?>
+--EXPECT--
+string(5) "pre-A"
+string(1) "A"
+string(5) "pre-B"
+string(1) "B"
+string(5) "pre-A"
+string(1) "A"

--- a/ext/tests/hook_multiple_interfaces.phpt
+++ b/ext/tests/hook_multiple_interfaces.phpt
@@ -1,0 +1,52 @@
+--TEST--
+Check hooks work with class implementing multiple interfaces
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(
+    'InterfaceA',
+    'hello',
+    function($obj) {
+        var_dump('pre-A');
+    },
+    null
+);
+
+\OpenTelemetry\Instrumentation\hook(
+    'InterfaceB',
+    'greet',
+    function($obj) {
+        var_dump('pre-B');
+    },
+    null
+);
+
+interface InterfaceA {
+    public function hello(): void;
+}
+
+interface InterfaceB {
+    public function greet(): void;
+}
+
+class MyClass implements InterfaceA, InterfaceB {
+    public function hello(): void
+    {
+        var_dump('hello');
+    }
+    public function greet(): void
+    {
+        var_dump('greet');
+    }
+}
+
+$c = new MyClass();
+$c->hello();
+$c->greet();
+?>
+--EXPECT--
+string(5) "pre-A"
+string(5) "hello"
+string(5) "pre-B"
+string(5) "greet"

--- a/ext/tests/hook_multiple_methods_same_class.phpt
+++ b/ext/tests/hook_multiple_methods_same_class.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Check hooks on multiple methods of the same class
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook('Demo', 'methodA', fn() => var_dump('pre-A'));
+\OpenTelemetry\Instrumentation\hook('Demo', 'methodB', fn() => var_dump('pre-B'));
+
+class Demo {
+    public function methodA(): void { var_dump('A'); }
+    public function methodB(): void { var_dump('B'); }
+}
+
+$d = new Demo();
+$d->methodA();
+$d->methodB();
+?>
+--EXPECT--
+string(5) "pre-A"
+string(1) "A"
+string(5) "pre-B"
+string(1) "B"

--- a/ext/tests/hook_no_callbacks.phpt
+++ b/ext/tests/hook_no_callbacks.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Check hook with no pre or post callbacks returns true but does nothing
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+var_dump(\OpenTelemetry\Instrumentation\hook(null, 'helloWorld', null, null));
+
+function helloWorld() {
+    var_dump('CALL');
+}
+
+helloWorld();
+?>
+--EXPECT--
+bool(true)
+string(4) "CALL"

--- a/ext/tests/hook_no_declaring_scope_for_function.phpt
+++ b/ext/tests/hook_no_declaring_scope_for_function.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Check declaring scope is null for non-class functions
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(
+    null,
+    'hello',
+    function($obj, array $params, ?string $class, string $function) {
+        var_dump($obj);
+        var_dump($class);
+    }
+);
+
+function hello(): void {}
+
+hello();
+?>
+--EXPECT--
+NULL
+NULL

--- a/ext/tests/hook_nonexistent_function.phpt
+++ b/ext/tests/hook_nonexistent_function.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Check hook on function that never gets defined does not error
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+var_dump(\OpenTelemetry\Instrumentation\hook(null, 'never_defined_function', fn() => var_dump('PRE')));
+var_dump('done');
+?>
+--EXPECT--
+bool(true)
+string(4) "done"

--- a/ext/tests/hook_only_post.phpt
+++ b/ext/tests/hook_only_post.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Check hook with only post callback (null pre)
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(null, 'helloWorld', null, fn() => var_dump('POST'));
+
+function helloWorld() {
+    var_dump('CALL');
+}
+
+helloWorld();
+?>
+--EXPECT--
+string(4) "CALL"
+string(4) "POST"

--- a/ext/tests/hook_only_pre.phpt
+++ b/ext/tests/hook_only_pre.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Check hook with only pre callback (null post)
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(null, 'helloWorld', fn() => var_dump('PRE'), null);
+
+function helloWorld() {
+    var_dump('CALL');
+}
+
+helloWorld();
+?>
+--EXPECT--
+string(3) "PRE"
+string(4) "CALL"

--- a/ext/tests/hook_recursive_function.phpt
+++ b/ext/tests/hook_recursive_function.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Check hooks work correctly with recursive functions
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(
+    null,
+    'factorial',
+    function($obj, array $params) {
+        var_dump('pre: ' . $params[0]);
+    },
+    function($obj, array $params, mixed $ret) {
+        var_dump('post: ' . $ret);
+    }
+);
+
+function factorial(int $n): int {
+    if ($n <= 1) return 1;
+    return $n * factorial($n - 1);
+}
+
+var_dump(factorial(3));
+?>
+--EXPECT--
+string(6) "pre: 3"
+string(6) "pre: 2"
+string(6) "pre: 1"
+string(7) "post: 1"
+string(7) "post: 2"
+string(7) "post: 6"
+int(6)

--- a/ext/tests/hook_return_value_no_return.phpt
+++ b/ext/tests/hook_return_value_no_return.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Check post hook receives null return value for void function
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(
+    null,
+    'helloWorld',
+    null,
+    function($obj, array $params, mixed $ret) {
+        var_dump($ret);
+    }
+);
+
+function helloWorld(): void {
+    // no return
+}
+
+helloWorld();
+?>
+--EXPECT--
+NULL

--- a/ext/tests/invalid_post_callback_signature_with_method.phpt
+++ b/ext/tests/invalid_post_callback_signature_with_method.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Test invalid post callback signature for class method
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+OpenTelemetry\Instrumentation\hook(
+    'TestClass',
+    'test',
+    null,
+    static function (array $params) {
+        //missing param 1 (object), incorrect type for param 1
+        var_dump('post');
+    }
+);
+
+class TestClass {
+    public static function test(): void
+    {
+        var_dump('test');
+    }
+}
+
+TestClass::test();
+?>
+--EXPECTF--
+string(4) "test"
+
+Warning: TestClass::test(): OpenTelemetry: post hook invalid signature, class=TestClass function=test in %s on line %d

--- a/ext/tests/minfo_disabled_output.phpt
+++ b/ext/tests/minfo_disabled_output.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Check if phpinfo() shows disabled status when conflicting extension found
+--EXTENSIONS--
+opentelemetry
+--INI--
+opentelemetry.conflicts=Core
+--FILE--
+<?php
+ob_start();
+phpinfo(INFO_MODULES);
+$info = ob_get_clean();
+
+preg_match('/opentelemetry hooks => (.+)/', $info, $matches);
+var_dump(trim($matches[1]));
+?>
+--EXPECTF--
+Notice: PHP Startup: Conflicting extension found (Core), OpenTelemetry extension will be disabled in %s
+string(19) "disabled (conflict)"

--- a/ext/tests/minfo_output.phpt
+++ b/ext/tests/minfo_output.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Check if phpinfo() displays opentelemetry module info correctly
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+ob_start();
+phpinfo(INFO_MODULES);
+$info = ob_get_clean();
+
+// Check for enabled status
+preg_match('/opentelemetry hooks => (\w+)/', $info, $matches);
+var_dump($matches[1]);
+
+// Check for extension version
+preg_match('/extension version => ([\d.]+)/', $info, $matches);
+var_dump(!empty($matches[1]));
+
+// Check INI settings are displayed
+var_dump(strpos($info, 'opentelemetry.conflicts') !== false);
+var_dump(strpos($info, 'opentelemetry.validate_hook_functions') !== false);
+var_dump(strpos($info, 'opentelemetry.allow_stack_extension') !== false);
+var_dump(strpos($info, 'opentelemetry.attr_hooks_enabled') !== false);
+?>
+--EXPECT--
+string(7) "enabled"
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/ext/tests/multiple_hooks_execution_order.phpt
+++ b/ext/tests/multiple_hooks_execution_order.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Check multiple hooks execute in correct order (pre: FIFO, post: LIFO)
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(null, 'hello',
+    fn() => var_dump('pre-1'),
+    fn() => var_dump('post-1')
+);
+\OpenTelemetry\Instrumentation\hook(null, 'hello',
+    fn() => var_dump('pre-2'),
+    fn() => var_dump('post-2')
+);
+\OpenTelemetry\Instrumentation\hook(null, 'hello',
+    fn() => var_dump('pre-3'),
+    fn() => var_dump('post-3')
+);
+
+function hello() {
+    var_dump('CALL');
+}
+
+hello();
+?>
+--EXPECT--
+string(5) "pre-1"
+string(5) "pre-2"
+string(5) "pre-3"
+string(4) "CALL"
+string(6) "post-3"
+string(6) "post-2"
+string(6) "post-1"

--- a/ext/tests/post_hook_exception_and_return.phpt
+++ b/ext/tests/post_hook_exception_and_return.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Check post hook receives both null return and exception when function throws
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(
+    null,
+    'helloWorld',
+    null,
+    function($obj, array $params, mixed $ret, ?Throwable $e) {
+        var_dump($ret);
+        var_dump($e instanceof Exception);
+        var_dump($e->getMessage());
+    }
+);
+
+function helloWorld() {
+    throw new Exception('boom');
+}
+
+try {
+    helloWorld();
+} catch (Exception $e) {
+    var_dump('caught: ' . $e->getMessage());
+}
+?>
+--EXPECT--
+NULL
+bool(true)
+string(4) "boom"
+string(12) "caught: boom"

--- a/ext/tests/post_hook_filename_lineno.phpt
+++ b/ext/tests/post_hook_filename_lineno.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Check post hook receives correct filename and line number
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(
+    null,
+    'helloWorld',
+    null,
+    function($obj, array $params, mixed $ret, ?Throwable $e, ?string $class, string $function, ?string $filename, ?int $lineno) {
+        var_dump($function);
+        var_dump(str_contains($filename, 'post_hook_filename_lineno.php'));
+        var_dump($lineno);
+    }
+);
+
+function helloWorld() {
+    return 'hello';
+}
+
+helloWorld();
+?>
+--EXPECT--
+string(10) "helloWorld"
+bool(true)
+int(13)

--- a/ext/tests/post_hook_modifies_return_with_type.phpt
+++ b/ext/tests/post_hook_modifies_return_with_type.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Check post hook replaces return value when it has a non-void return type
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(null, 'helloWorld', post: function(mixed $object, array $params, string $return): string {
+    return 'replaced';
+});
+
+function helloWorld(string $val): string {
+    return $val;
+}
+
+var_dump(helloWorld('original'));
+?>
+--EXPECT--
+string(8) "replaced"

--- a/ext/tests/post_hook_no_exception.phpt
+++ b/ext/tests/post_hook_no_exception.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Check post hook receives null exception when function succeeds
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(
+    null,
+    'helloWorld',
+    null,
+    function($obj, array $params, mixed $ret, ?Throwable $e) {
+        var_dump($ret);
+        var_dump($e);
+    }
+);
+
+function helloWorld(): string {
+    return 'success';
+}
+
+helloWorld();
+?>
+--EXPECT--
+string(7) "success"
+NULL

--- a/ext/tests/post_hook_nullable_return.phpt
+++ b/ext/tests/post_hook_nullable_return.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Check post hook can return null to replace return value when return type is nullable
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(null, 'helloWorld', post: function(mixed $object, array $params, ?string $return): ?string {
+    return null;
+});
+
+function helloWorld(string $val): ?string {
+    return $val;
+}
+
+var_dump(helloWorld('foo'));
+?>
+--EXPECT--
+NULL

--- a/ext/tests/post_hook_void_return_type.phpt
+++ b/ext/tests/post_hook_void_return_type.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Check post hook with void return type does not modify return value
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(null, 'helloWorld', post: function(mixed $object, array $params, string $return): void {
+    // void return type means return value should not be modified
+});
+
+function helloWorld(string $val): string {
+    return $val;
+}
+
+var_dump(helloWorld('foo'));
+?>
+--EXPECT--
+string(3) "foo"

--- a/ext/tests/pre_hook_filename_lineno.phpt
+++ b/ext/tests/pre_hook_filename_lineno.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Check pre hook receives correct filename and line number
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(
+    null,
+    'helloWorld',
+    function($obj, array $params, ?string $class, string $function, ?string $filename, ?int $lineno) {
+        var_dump($function);
+        var_dump(str_contains($filename, 'pre_hook_filename_lineno.php'));
+        var_dump($lineno);
+    }
+);
+
+function helloWorld() {
+    var_dump('CALL');
+}
+
+helloWorld();
+?>
+--EXPECT--
+string(10) "helloWorld"
+bool(true)
+int(12)
+string(4) "CALL"

--- a/ext/tests/pre_hook_modify_single_param.phpt
+++ b/ext/tests/pre_hook_modify_single_param.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Check pre hook modifying a single positional parameter
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(null, 'hello',
+    function($obj, array $params) {
+        return ['modified'];
+    }
+);
+
+function hello(string $val) {
+    var_dump($val);
+}
+
+hello('original');
+?>
+--EXPECT--
+string(8) "modified"

--- a/ext/tests/pre_hook_returns_non_array.phpt
+++ b/ext/tests/pre_hook_returns_non_array.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Check pre hook returning non-array value does not modify params
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(null, 'hello',
+    function($obj, array $params) {
+        return 'not an array';
+    }
+);
+
+function hello(string $val) {
+    var_dump($val);
+}
+
+hello('original');
+?>
+--EXPECT--
+string(8) "original"

--- a/ext/tests/pre_hook_returns_null.phpt
+++ b/ext/tests/pre_hook_returns_null.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Check pre hook returning null does not modify params
+--EXTENSIONS--
+opentelemetry
+--FILE--
+<?php
+\OpenTelemetry\Instrumentation\hook(null, 'hello',
+    function($obj, array $params) {
+        return null;
+    }
+);
+
+function hello(string $val) {
+    var_dump($val);
+}
+
+hello('original');
+?>
+--EXPECT--
+string(8) "original"

--- a/ext/tests/span_attribute/null_value_filtered.phpt
+++ b/ext/tests/span_attribute/null_value_filtered.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Check SpanAttribute with null value is filtered out
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80100) die('skip requires PHP >= 8.1'); ?>
+--EXTENSIONS--
+opentelemetry
+--INI--
+opentelemetry.attr_hooks_enabled = On
+--FILE--
+<?php
+namespace OpenTelemetry\API\Instrumentation;
+
+include dirname(__DIR__) . '/mocks/WithSpan.php';
+include dirname(__DIR__) . '/mocks/SpanAttribute.php';
+include dirname(__DIR__) . '/mocks/WithSpanHandlerDumpAttributes.php';
+use OpenTelemetry\API\Instrumentation\WithSpan;
+use OpenTelemetry\API\Instrumentation\SpanAttribute;
+
+#[WithSpan]
+function foo(#[SpanAttribute] ?string $name = null): void
+{
+    var_dump('test');
+}
+
+foo(null);
+?>
+--EXPECT--
+string(3) "pre"
+array(0) {
+}
+string(4) "test"
+string(4) "post"

--- a/ext/tests/validate_hook_functions_on.phpt
+++ b/ext/tests/validate_hook_functions_on.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Check validate_hook_functions=On rejects invalid pre hook signature
+--EXTENSIONS--
+opentelemetry
+--INI--
+opentelemetry.validate_hook_functions=On
+--FILE--
+<?php
+OpenTelemetry\Instrumentation\hook(
+    null,
+    'hello',
+    static function (array $params) {
+        // first param should be object/null, not array
+        var_dump('pre should not run');
+    },
+    null
+);
+
+function hello() {
+    var_dump('CALL');
+}
+
+hello();
+?>
+--EXPECTF--
+Warning: hello(): OpenTelemetry: pre hook invalid signature, class=null function=hello in %s on line %d
+string(4) "CALL"

--- a/ext/tests/with_span/attribute_skipped_when_hooks_exist.phpt
+++ b/ext/tests/with_span/attribute_skipped_when_hooks_exist.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Check WithSpan attribute hooks are skipped when manual hooks already exist
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80100) die('skip requires PHP >= 8.1'); ?>
+--EXTENSIONS--
+opentelemetry
+--INI--
+opentelemetry.attr_hooks_enabled = On
+opentelemetry.attr_pre_handler_function = default_pre
+opentelemetry.attr_post_handler_function = default_post
+--FILE--
+<?php
+include dirname(__DIR__) . '/mocks/WithSpan.php';
+use OpenTelemetry\API\Instrumentation\WithSpan;
+
+function default_pre(): void
+{
+    var_dump('default_pre: should not be called');
+}
+
+function default_post(): void
+{
+    var_dump('default_post: should not be called');
+}
+
+// Register manual hooks before the WithSpan-attributed function is called
+\OpenTelemetry\Instrumentation\hook(null, 'foo',
+    fn() => var_dump('manual_pre'),
+    fn() => var_dump('manual_post')
+);
+
+#[WithSpan]
+function foo(): void
+{
+    var_dump('test');
+}
+
+foo();
+?>
+--EXPECT--
+string(10) "manual_pre"
+string(4) "test"
+string(11) "manual_post"

--- a/ext/tests/with_span/attribute_with_all_args.phpt
+++ b/ext/tests/with_span/attribute_with_all_args.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Check WithSpan attribute with name, span_kind, and attributes
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80100) die('skip requires PHP >= 8.1'); ?>
+--EXTENSIONS--
+opentelemetry
+--INI--
+opentelemetry.attr_hooks_enabled = On
+opentelemetry.attr_pre_handler_function = custom_pre
+opentelemetry.attr_post_handler_function = custom_post
+--FILE--
+<?php
+include dirname(__DIR__) . '/mocks/WithSpan.php';
+use OpenTelemetry\API\Instrumentation\WithSpan;
+
+function custom_pre($obj, array $params, ?string $class, string $function, ?string $filename, ?int $lineno, array $attr_args, array $attributes): void
+{
+    var_dump('pre');
+    var_dump($attr_args);
+}
+
+function custom_post(): void
+{
+    var_dump('post');
+}
+
+#[WithSpan('my-span', 1, attributes: ['key' => 'value'])]
+function foo(): void
+{
+    var_dump('test');
+}
+
+foo();
+?>
+--EXPECT--
+string(3) "pre"
+array(2) {
+  ["name"]=>
+  string(7) "my-span"
+  ["span_kind"]=>
+  int(1)
+}
+string(4) "test"
+string(4) "post"


### PR DESCRIPTION
## Summary

Adds 48 new PHPT test files (75 → 123 total) to improve test coverage across previously untested code paths. All tests pass on PHP 8.3 (2 skipped due to missing pcntl extension).

## Files Changed

### Conflict Detection (4 tests)
- `conflicts_empty_string.phpt` — verifies no conflict when `opentelemetry.conflicts` is empty
- `conflicts_multiple_extensions.phpt` — comma-separated list with mix of matching/non-matching extensions
- `conflicts_no_match.phpt` — listed extensions not loaded, extension stays enabled
- `conflicts_spaces.phpt` — space-separated conflict list is parsed correctly

### MINFO / phpinfo Output (2 tests)
- `minfo_output.phpt` — phpinfo displays "enabled", version, and all INI settings
- `minfo_disabled_output.phpt` — phpinfo displays "disabled (conflict)" when conflicting extension found

### Stack Extension (1 test)
- `expand_params_no_stack_extension.phpt` — expanding params with `allow_stack_extension=Off` produces warning

### Hook Registration Edge Cases (7 tests)
- `hook_only_pre.phpt` — hook with only pre callback (null post)
- `hook_only_post.phpt` — hook with only post callback (null pre)
- `hook_no_callbacks.phpt` — hook with null pre and null post returns true, does nothing
- `hook_invalid_arguments.phpt` — too few args and non-closure type errors
- `hook_function_not_yet_defined.phpt` — hook registered before function definition
- `hook_class_not_yet_defined.phpt` — hook registered before class definition
- `hook_nonexistent_function.phpt` — hook on never-defined function does not error

### Class Hierarchy (5 tests)
- `hook_instance_method.phpt` — instance method provides object as 1st param
- `hook_inherited_method.phpt` — parent class hook fires for child class
- `hook_interface_method.phpt` — interface hook fires for implementing class
- `hook_deep_inheritance.phpt` — hooks work with 3+ level class hierarchy
- `hook_multiple_interfaces.phpt` — hooks on multiple interfaces work independently

### Hook Behavior (7 tests)
- `multiple_hooks_execution_order.phpt` — pre hooks FIFO, post hooks LIFO
- `hook_case_insensitive.phpt` — function name matching is case-insensitive
- `hook_class_case_insensitive.phpt` — class name matching is case-insensitive
- `hook_recursive_function.phpt` — hooks fire correctly on recursive calls
- `hook_multiple_functions.phpt` — hooks on different functions work independently
- `hook_multiple_methods_same_class.phpt` — hooks on different methods of same class
- `hook_disabled_extension.phpt` — hooks do not fire when disabled by conflict

### Parameter Handling (4 tests)
- `hook_function_with_default_params.phpt` — hook sees only provided params, not defaults
- `hook_function_variadic.phpt` — hook receives all variadic arguments
- `pre_hook_modify_single_param.phpt` — pre hook modifies a single positional parameter
- `pre_hook_returns_non_array.phpt` / `pre_hook_returns_null.phpt` — non-array/null returns don't modify params

### Return Value & Exception Handling (5 tests)
- `post_hook_void_return_type.phpt` — void return type in post hook doesn't modify return value
- `post_hook_nullable_return.phpt` — post hook can return null for nullable return type
- `post_hook_modifies_return_with_type.phpt` — post hook replaces return value with typed return
- `post_hook_exception_and_return.phpt` — post hook receives null return and exception on throw
- `post_hook_no_exception.phpt` — post hook receives null exception on success

### Filename, Line Number & Scope (5 tests)
- `pre_hook_filename_lineno.phpt` — pre hook receives correct filename and line number
- `post_hook_filename_lineno.phpt` — post hook receives correct filename and line number
- `hook_internal_filename_null.phpt` — internal functions have null filename/lineno
- `hook_declaring_scope.phpt` — declaring scope provided for class method hooks
- `hook_no_declaring_scope_for_function.phpt` — declaring scope is null for plain functions

### Validation (2 tests)
- `validate_hook_functions_on.phpt` — `validate_hook_functions=On` rejects invalid pre hook
- `invalid_post_callback_signature_with_method.phpt` — invalid post hook signature for class method

### Hook Return Value (1 test)
- `hook_return_value_no_return.phpt` — post hook receives null for void function

### Internal Function Hooks (1 test)
- `hook_internal_method.phpt` — hooks work on internal class methods (PHP 8.2+)

### WithSpan Attributes (2 tests)
- `with_span/attribute_with_all_args.phpt` — WithSpan with name, span_kind, and attributes
- `with_span/attribute_skipped_when_hooks_exist.phpt` — manual hooks take priority over WithSpan

### SpanAttribute (1 test)
- `span_attribute/null_value_filtered.phpt` — null parameter value filtered from attributes

## Test plan
- [x] All 123 tests pass in Docker (PHP 8.3, Debian)
- [ ] CI passes on Linux (PHP 8.1–8.4)
- [ ] CI passes on macOS (PHP 8.1–8.4)
- [ ] CI passes on Windows (PHP 8.1–8.4, TS/NTS)