### PR TITLE
fix: addref #[WithSpan] attribute args to prevent refcount over-free

### DIFF
--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -349,6 +349,10 @@ static inline void func_get_attribute_args(zval *zv, HashTable *attributes,
                 zend_hash_copy(attributes, array_ht, zval_add_ref);
             }
         } else {
+            // arg.value is borrowed from the op_array's cached zend_attribute,
+            // so ref it to balance ht's ZVAL_PTR_DTOR teardown - same as the
+            // zval_add_ref used for the attributes copy above.
+            Z_TRY_ADDREF(arg.value);
             if (arg.name != NULL) {
                 zend_hash_add(ht, arg.name, &arg.value);
             } else {

--- a/ext/tests/with_span/attribute_args_not_over_freed.phpt
+++ b/ext/tests/with_span/attribute_args_not_over_freed.phpt
@@ -1,0 +1,41 @@
+--TEST--
+WithSpan attribute args are not over-freed across repeated observed calls
+--DESCRIPTION--
+Regression test for https://github.com/open-telemetry/opentelemetry-php/issues/2002
+observer_begin() must not decrement the refcount of the values cached on the
+op_array's #[WithSpan(...)] attribute. opcache is disabled so the literal stays a
+refcounted (non-interned) zend_string, which is where the over-free bit.
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80100) die('skip requires PHP >= 8.1'); ?>
+--EXTENSIONS--
+opentelemetry
+--INI--
+opentelemetry.attr_hooks_enabled = On
+opcache.enable_cli = 0
+--FILE--
+<?php
+namespace OpenTelemetry\API\Instrumentation;
+
+include dirname(__DIR__) . '/mocks/WithSpan.php';
+use OpenTelemetry\API\Instrumentation\WithSpan;
+
+class WithSpanHandler
+{
+    public static function pre(): void {}
+    public static function post(): void {}
+}
+
+class Demo
+{
+    #[WithSpan('demo.operation')]
+    public function work(): void {}
+}
+
+$d = new Demo();
+for ($i = 0; $i < 1000000; $i++) {
+    $d->work();
+}
+echo "done\n";
+?>
+--EXPECT--
+done


### PR DESCRIPTION
## Description

Fixes open-telemetry/opentelemetry-php#2002 (filed on the `opentelemetry-php` mirror; the affected code lives in this repo).

`func_get_attribute_args()` builds the `#[WithSpan(...)]` argument array that is passed to the hooks as `params[6]`. It inserts each attribute-argument value into a `HashTable` whose element destructor is `ZVAL_PTR_DTOR`, but does so with `zend_hash_add` **without taking a reference**:

```c
zend_hash_add(ht, arg.name, &arg.value);   // no addref
...
zend_hash_add(ht, key, &arg.value);        // no addref
```

`ht` comes back as `params[6]` and is torn down in the cleanup loop at the end of `observer_begin()` (`zval_dtor(&params[i])`). So every observed call **net-decrements each attribute argument by one**. Those values are borrowed from the op_array's cached `zend_attribute`, so once enough calls have gone through, the refcount reaches zero, the value is freed out from under the attribute, and the next read faults.

opcache masks this: it interns the literals, so the extra decref is a no-op on interned strings. With opcache disabled the literals are refcounted `zend_string`s and the over-free bites — a heap use-after-free that surfaces as `zend_mm_heap corrupted`.

The `attributes` copy immediately above already handles this correctly via `zend_hash_copy(attributes, array_ht, zval_add_ref)`. This change does the same thing for the scalar/string args.

## Fix

Take a reference on each value as it is added to the table:

```c
Z_TRY_ADDREF(arg.value);
```

`Z_TRY_ADDREF` is a no-op for non-refcounted values, so integer/enum `span_kind` args are unaffected.

## Testing

Added `ext/tests/with_span/attribute_args_not_over_freed.phpt` — the issue's reproduction (1,000,000 observed calls to a method carrying `#[WithSpan('demo.operation')]`, with opcache disabled so the literal stays a refcounted, non-interned `zend_string`).

Verified locally on **PHP 8.5.6 (NTS, arm64 macOS)** — not the reporter's Alpine/musl 8.4.22, but the trigger (opcache off ⇒ attribute literals are refcounted rather than interned) is platform-independent:

- **`make test` (run-tests.php, which drives the phpdbg SAPI here):** the new test FAILs before the fix with `zend_mm_heap corrupted` (`Termsig=6`) and PASSes after; full suite 76/76.
- **Direct check under the CLI SAPI** (`php -d opcache.enable_cli=0 -d opentelemetry.attr_hooks_enabled=1`), running the 1M-call reproduction:
  - unfixed extension → aborts with `zend_mm_heap corrupted` (SIGABRT / exit 134);
  - unfixed extension **with opcache on** → completes cleanly (confirms the interning-masks-it explanation);
  - fixed extension → completes cleanly.
- **`clang-format` v16** (the version pinned in `check-style.yml`): clean, no changes.
