### PR TITLE
fix: addref #[SpanAttribute] parameter values to prevent refcount over-free

### DIFF
--- a/ext/otel_observer.c
+++ b/ext/otel_observer.c
@@ -218,13 +218,16 @@ static void func_get_args(zval *zv, HashTable *attributes,
                     zend_attribute *attribute =
                         find_spanattribute_attribute(ex->func, i);
                     if (attribute != NULL && is_valid_attribute_value(p)) {
-                        if (attribute->argc) {
-                            zend_string *key = Z_STR(attribute->args[0].value);
-                            zend_hash_del(attributes, key);
-                            zend_hash_add(attributes, key, p);
-                        } else {
-                            zend_hash_del(attributes, arg_name);
-                            zend_hash_add(attributes, arg_name, p);
+                        zend_string *key = attribute->argc
+                                               ? Z_STR(attribute->args[0].value)
+                                               : arg_name;
+                        zend_hash_del(attributes, key);
+                        // p is borrowed from the caller's frame, so ref it to
+                        // balance the attributes HashTable's ZVAL_PTR_DTOR
+                        // teardown - same as func_get_attribute_args() does for
+                        // the values cached on the WithSpan attribute.
+                        if (zend_hash_add(attributes, key, p) != NULL) {
+                            Z_TRY_ADDREF_P(p);
                         }
                     }
                 }

--- a/ext/tests/span_attribute/refcounted_values.phpt
+++ b/ext/tests/span_attribute/refcounted_values.phpt
@@ -1,0 +1,68 @@
+--TEST--
+Check that SpanAttribute keeps the caller's refcounted values valid
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80100) die('skip requires PHP >= 8.1'); ?>
+--EXTENSIONS--
+opentelemetry
+--INI--
+opentelemetry.attr_hooks_enabled = On
+--FILE--
+<?php
+namespace OpenTelemetry\API\Instrumentation;
+
+include dirname(__DIR__) . '/mocks/WithSpan.php';
+include dirname(__DIR__) . '/mocks/SpanAttribute.php';
+include dirname(__DIR__) . '/mocks/WithSpanHandler.php';
+use OpenTelemetry\API\Instrumentation\WithSpan;
+use OpenTelemetry\API\Instrumentation\SpanAttribute;
+
+#[WithSpan]
+function foo(
+    #[SpanAttribute] string $one,
+    #[SpanAttribute] array $two
+): void
+{
+}
+
+// str_repeat() and range() build their results at run time, so both values are
+// refcounted. A literal would be an interned string, and an interned string
+// hides a missing reference count increment.
+$one = str_repeat('a', 32);
+$two = range(1, 4);
+
+for ($i = 0; $i < 5; $i++) {
+    foo($one, $two);
+}
+
+// Take the memory again. If the hook released the values too soon, the new
+// allocations overwrite them.
+$filler = [];
+for ($i = 0; $i < 2000; $i++) {
+    $filler[] = str_repeat('X', 32);
+}
+
+var_dump($one);
+var_dump($two);
+?>
+--EXPECT--
+string(3) "pre"
+string(4) "post"
+string(3) "pre"
+string(4) "post"
+string(3) "pre"
+string(4) "post"
+string(3) "pre"
+string(4) "post"
+string(3) "pre"
+string(4) "post"
+string(32) "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+array(4) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+  [3]=>
+  int(4)
+}


### PR DESCRIPTION
`func_get_args()` adds the values of parameters marked `#[SpanAttribute]` to the `attributes` HashTable with `zend_hash_add` and without taking a reference. That table's element dtor is `ZVAL_PTR_DTOR` and `observer_begin()` tears it down at the end of every observed call, so each call net-decrements the value by one. The value is borrowed from the caller's frame, so it is eventually freed while the caller still holds it (heap use-after-free / `zend_mm_heap corrupted`).

This is the same over-free that #313 fixed in `func_get_attribute_args()` for the values cached on `#[WithSpan(...)]`. The `#[SpanAttribute]` path was missed. The fix takes the reference in the same way, and folds the two `zend_hash_add` branches into one so the refcount handling has a single home.

Only refcounted values are affected, which is what makes this easy to miss: ints, bools, floats and interned literal strings all make the absent addref and the decref cancel out. Every existing test in `ext/tests/span_attribute/` passes literals, so the suite stayed green while the bug was live. The new test builds its values with `str_repeat()` and `range()` so they are refcounted regardless of opcache.

### Verification

Built against PHP 8.4.17 NTS (`php:8.4-fpm-trixie`):

| | `refcounted_values.phpt` | full suite |
|---|---|---|
| before | fail | 124/124 pass |
| after | pass | 125/125 pass |

`clang-format` leaves the change unmodified.

Fixes open-telemetry/opentelemetry-php#2031
